### PR TITLE
revert: Revert "build(deps-dev): bump cypress from 8.5.0 to 8.6.0 in /client"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "@quasar/quasar-app-extension-testing-unit-jest": "^2.2.2",
     "axe-core": "^4.3.3",
     "babel-eslint": "^10.0.1",
-    "cypress": "^8.6.0",
+    "cypress": "^8.5.0",
     "cypress-axe": "^0.13.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4173,10 +4173,10 @@ cypress@^6.8.0:
     url "^0.11.0"
     yauzl "^2.10.0"
 
-cypress@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.6.0.tgz#8d02fa58878b37cfc45bbfce393aa974fa8a8e22"
-  integrity sha512-F7qEK/6Go5FsqTueR+0wEw2vOVKNgk5847Mys8vsWkzPoEKdxs+7N9Y1dit+zhaZCLtMPyrMwjfA53ZFy+lSww==
+cypress@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.5.0.tgz#5712ca170913f8344bf167301205c4217c1eb9bd"
+  integrity sha512-MMkXIS+Ro2KETn4gAlG3tIc/7FiljuuCZP0zpd9QsRG6MZSyZW/l1J3D4iQM6WHsVxuX4rFChn5jPFlC2tNSvQ==
   dependencies:
     "@cypress/request" "^2.88.6"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Reverts MESH-Research/CCR#638

This PR is giving errors. After Discussion by the team it was decided to revert this PR