### PR TITLE
fix: Fix submitting a submission for review on the Submissions page

### DIFF
--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -170,7 +170,7 @@
                           class="items-center"
                           clickable
                           @click="
-                            confirmHandler('accept_for_review', submission.id)
+                            confirmHandler('submit_for_review', submission.id)
                           "
                           >{{
                             $t("submission.action.submit_for_review")


### PR DESCRIPTION
This fixes the dialog form that appears when submitting a submission for review on the Submissions page so that the correct language appears.

Closes #1730 