### PR TITLE
fix: Make cancel button appear when modifying comments

### DIFF
--- a/client/src/components/forms/CommentEditor.vue
+++ b/client/src/components/forms/CommentEditor.vue
@@ -60,12 +60,7 @@
         <q-btn type="submit" color="accent">
           {{ $t("guiElements.form.submit") }}
         </q-btn>
-        <q-btn
-          v-if="commentType !== 'OverallComment' && isModifying === false"
-          ref="cancel_button"
-          flat
-          @click="cancelHandler()"
-        >
+        <q-btn ref="cancel_button" flat @click="cancelHandler()">
           {{ $t("guiElements.form.cancel") }}
         </q-btn>
       </q-card-actions>


### PR DESCRIPTION
This makes cancel buttons appear for both inline and overall comments when a user is modifying them.

Closes #1616 