### PR TITLE
fix: Fix email verification

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -145,6 +145,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'email',
         ]);
         unset($array['profile_metadata']);
+
         return $array;
     }
 

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -139,14 +139,15 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function toSearchableArray()
     {
-        $array = $this->withoutRelations()->toArray([
-            'username',
-            'name',
-            'email',
-        ]);
-        unset($array['profile_metadata'], $array['email_verified_at'], $array['created_at'], $array['updated_at']);
-
-        return $array;
+        return $this
+            ->withoutRelations()
+            ->setVisible([
+                'id',
+                'username',
+                'name',
+                'email',
+            ])
+            ->toArray();
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -133,26 +133,17 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
-     * Get the indexable data array for the model. Currently:
-     *
-     *     username
-     *     name
-     *     email
-     *     email_verified_at
-     *     updated_at
-     *     created_at
-     *     id
+     * Get the indexable data array for the model
      *
      * @return array
      */
     public function toSearchableArray()
     {
-        $array = $this->toArray();
-
-        // Customize array...
-        unset($array['profile_metadata']);
-
-        return $array;
+        return $this->withoutRelations()->toArray([
+            'username',
+            'name',
+            'email',
+        ]);
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -139,11 +139,13 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function toSearchableArray()
     {
-        return $this->withoutRelations()->toArray([
+        $array = $this->withoutRelations()->toArray([
             'username',
             'name',
             'email',
         ]);
+        unset($array['profile_metadata']);
+        return $array;
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -144,7 +144,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'name',
             'email',
         ]);
-        unset($array['profile_metadata']);
+        unset($array['profile_metadata'], $array['email_verified_at'], $array['created_at'], $array['updated_at']);
 
         return $array;
     }

--- a/client/src/pages/VerifyEmail.vue
+++ b/client/src/pages/VerifyEmail.vue
@@ -62,8 +62,6 @@ const { errorMessages, graphQLErrorCodes } = useGraphErrors()
 onMounted(async () => {
   const { token, expires } = params
 
-  await currentUser
-  console.log(currentUser.value)
   if (await currentUser.value.email_verified_at) {
     status.value = "success"
     return
@@ -72,7 +70,6 @@ onMounted(async () => {
     await verifyEmail({ token, expires })
     status.value = "success"
   } catch (error) {
-    console.log(error)
     errorMessagesList.value = errorMessages(
       graphQLErrorCodes(error),
       "account.failures"

--- a/client/src/pages/VerifyEmail.vue
+++ b/client/src/pages/VerifyEmail.vue
@@ -62,7 +62,8 @@ const { errorMessages, graphQLErrorCodes } = useGraphErrors()
 onMounted(async () => {
   const { token, expires } = params
 
-  if (await currentUser.value.email_verified_at) {
+  await currentUser
+  if (currentUser.value.email_verified_at) {
     status.value = "success"
     return
   }

--- a/client/src/pages/VerifyEmail.vue
+++ b/client/src/pages/VerifyEmail.vue
@@ -62,7 +62,9 @@ const { errorMessages, graphQLErrorCodes } = useGraphErrors()
 onMounted(async () => {
   const { token, expires } = params
 
-  if (currentUser.value.email_verified_at) {
+  await currentUser
+  console.log(currentUser.value)
+  if (await currentUser.value.email_verified_at) {
     status.value = "success"
     return
   }
@@ -70,6 +72,7 @@ onMounted(async () => {
     await verifyEmail({ token, expires })
     status.value = "success"
   } catch (error) {
+    console.log(error)
     errorMessagesList.value = errorMessages(
       graphQLErrorCodes(error),
       "account.failures"


### PR DESCRIPTION
This pull request simplifies the searchable array used by TNTSearch so that only the most essential data is used for tokenization to prevent disruptions. It also adds an `await` keyword to the client template to address cases where current user data may not be available at the same time the email verification page has mounted.

Closes #1673 