### PR TITLE
feat: Add the Reviews page

### DIFF
--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -92,15 +92,15 @@
         :aria-label="$t('header.nav_aria_label')"
       >
         <q-item v-if="currentUser" role="link" to="/dashboard">
-          <q-item-section side>
-            <q-icon name="dashboard" />
+          <q-item-section side class="gt-xs">
+            <q-icon class="gt-xs" name="dashboard" />
           </q-item-section>
           <q-item-section>
             {{ $t("header.dashboard") }}
           </q-item-section>
         </q-item>
         <q-item to="/publications" role="link">
-          <q-item-section side>
+          <q-item-section side class="gt-xs">
             <q-icon name="collections_bookmark" />
           </q-item-section>
           <q-item-section>
@@ -108,7 +108,7 @@
           </q-item-section>
         </q-item>
         <q-item data-cy="submissions_link" to="/submissions" role="link">
-          <q-item-section side>
+          <q-item-section side class="gt-xs">
             <q-icon name="content_copy" />
           </q-item-section>
           <q-item-section>
@@ -116,8 +116,8 @@
           </q-item-section>
         </q-item>
         <q-item data-cy="reviews_link" to="/reviews" role="link">
-          <q-item-section side>
-            <q-icon name="content_copy" />
+          <q-item-section side class="gt-xs">
+            <q-icon class="material-icons-outlined" name="rate_review" />
           </q-item-section>
           <q-item-section>
             {{ $t("header.reviews") }}

--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -115,6 +115,14 @@
             {{ $t("header.submissions") }}
           </q-item-section>
         </q-item>
+        <q-item data-cy="reviews_link" to="/reviews" role="link">
+          <q-item-section side>
+            <q-icon name="content_copy" />
+          </q-item-section>
+          <q-item-section>
+            {{ $t("header.reviews") }}
+          </q-item-section>
+        </q-item>
       </q-list>
     </div>
   </q-header>

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -50,7 +50,7 @@
       </div>
     </template>
     <template #body="props">
-      <q-tr key="id" :props="props">
+      <q-tr :props="props">
         <q-td key="id" :props="props">
           {{ props.row.id }}
         </q-td>

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -1,17 +1,25 @@
 <template>
-  <q-table bordered flat :columns="cols" :rows="tableData" row-key="id" dense>
+  <q-table
+    bordered
+    flat
+    square
+    :columns="cols"
+    :rows="tableData"
+    row-key="id"
+    dense
+  >
     <template #top>
       <div>
-        <h3 class="q-my-none">{{ tableTitle }}</h3>
+        <h3 class="q-my-none">{{ title }}</h3>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <p v-html="tableByline"></p>
+        <p v-html="byline"></p>
       </div>
     </template>
     <template #no-data>
       <div class="full-width row flex-center text--grey q-py-xl">
         <p class="text-h3">
-          There are no {{ type == "reviews" ? "reviews" : "submissions" }} for
-          you.
+          There are no
+          {{ tableType == "reviews" ? "reviews" : "submissions" }} for you.
         </p>
       </div>
     </template>
@@ -42,43 +50,32 @@
           {{ $t(`submission.status.${props.row.status}`) }}
         </q-td>
         <q-td key="actions" :props="props">
-          <q-btn flat icon="more_vert">
-            <q-menu anchor="bottom right" self="top right">
-              <q-item
-                clickable
-                :to="{
-                  name: 'submission_details',
-                  params: { id: props.row.id },
-                }"
-                ><q-item-section>Submission Details</q-item-section></q-item
-              >
-              <q-item clickable>
-                <q-item-section data-cy="change_status_item_section">
-                  <q-item-label> Change Status </q-item-label>
-                </q-item-section>
-              </q-item>
-            </q-menu>
-          </q-btn>
+          <submission-table-actions
+            :submission="props.row"
+            action-type="reviews"
+          />
         </q-td>
       </q-tr>
     </template>
   </q-table>
 </template>
 <script setup>
+import SubmissionTableActions from "./SubmissionTableActions.vue"
+
 defineProps({
   tableData: {
     type: Array,
     default: () => [],
   },
-  tableTitle: {
+  title: {
     type: String,
     default: "",
   },
-  tableByline: {
+  byline: {
     type: String,
     default: "",
   },
-  type: {
+  tableType: {
     type: String,
     default: "",
   },

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -12,7 +12,9 @@
     <template #top>
       <div class="row full-width justify-between q-pb-md">
         <div class="column">
-          <h3 class="q-my-none">{{ $t(title) }}</h3>
+          <h3 class="q-my-none">
+            {{ $t(`submission_tables.${role}.title`) }}
+          </h3>
           <!-- eslint-disable-next-line vue/no-v-html -->
           <p class="q-mb-none" v-html="$t(byline)"></p>
         </div>
@@ -46,39 +48,41 @@
     </template>
     <template #no-data>
       <div class="full-width row flex-center text--grey q-py-lg">
-        <p class="text-h3">{{ $t(noData) }}</p>
+        <p class="text-h3">
+          {{ $t(`submission_tables.${tableType}.no_data`) }}
+        </p>
       </div>
     </template>
-    <template #body="props">
-      <q-tr :props="props">
-        <q-td key="id" :props="props">
+    <template #body="p">
+      <q-tr :props="p">
+        <q-td key="id" :props="p">
           {{ props.row.id }}
         </q-td>
-        <q-td key="title" :props="props">
+        <q-td key="title" :props="p">
           <router-link
             :to="{
               name: 'submission_review',
-              params: { id: props.row.id },
+              params: { id: p.row.id },
             }"
-            >{{ props.row.title }}
+            >{{ p.row.title }}
           </router-link>
         </q-td>
-        <q-td key="publication" :props="props">
+        <q-td key="publication" :props="p">
           <router-link
             :to="{
               name: 'publication:home',
-              params: { id: props.row.publication.id },
+              params: { id: p.row.publication.id },
             }"
-            >{{ props.row.publication.name }}
+            >{{ p.row.publication.name }}
           </router-link>
         </q-td>
-        <q-td key="status" :props="props">
-          {{ $t(`submission.status.${props.row.status}`) }}
+        <q-td key="status" :props="p">
+          {{ $t(`submission.status.${p.row.status}`) }}
         </q-td>
-        <q-td key="actions" :props="props">
+        <q-td key="actions" :props="p">
           <submission-table-actions
-            :submission="props.row"
-            action-type="reviews"
+            :submission="p.row"
+            :action-type="tableType"
             flat
           />
         </q-td>
@@ -92,33 +96,26 @@ import { useI18n } from "vue-i18n"
 import { ref, computed } from "vue"
 const { t } = useI18n()
 
-const propsVar = defineProps({
+const props = defineProps({
   tableData: {
     type: Array,
     default: () => [],
   },
-  title: {
-    type: String,
-    default: "",
-  },
-  byline: {
-    type: String,
-    default: "",
-  },
   tableType: {
     type: String,
-    default: "",
+    default: "submissions",
   },
-  noData: {
+  role: {
     type: String,
-    default: "reviews.tables.no_data",
+    default: "reviewer",
   },
 })
 const status_filter = ref(null)
 const unique = (items) => [...new Set(items)]
 const unique_statuses = computed(() => {
-  return unique(propsVar.tableData.map((item) => item.status))
+  return unique(props.tableData.map((item) => item.status))
 })
+const byline = `submission_tables.${props.role}.byline`
 const cols = [
   {
     name: "id",

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -53,40 +53,41 @@
         </p>
       </div>
     </template>
-    <template #body="p">
-      <q-tr :props="p">
-        <q-td key="id" :props="p">
-          {{ p.row.id }}
-        </q-td>
-        <q-td key="title" :props="p">
-          <router-link
-            :to="{
-              name: 'submission_review',
-              params: { id: p.row.id },
-            }"
-            >{{ p.row.title }}
-          </router-link>
-        </q-td>
-        <q-td key="publication" :props="p">
-          <router-link
-            :to="{
-              name: 'publication:home',
-              params: { id: p.row.publication.id },
-            }"
-            >{{ p.row.publication.name }}
-          </router-link>
-        </q-td>
-        <q-td key="status" :props="p">
-          {{ $t(`submission.status.${p.row.status}`) }}
-        </q-td>
-        <q-td key="actions" :props="p">
-          <submission-table-actions
-            :submission="p.row"
-            :action-type="tableType"
-            flat
-          />
-        </q-td>
-      </q-tr>
+    <template #body-cell-title="p">
+      <q-td :props="p">
+        <router-link
+          :to="{
+            name: 'submission_review',
+            params: { id: p.row.id },
+          }"
+          >{{ p.row.title }}
+        </router-link>
+      </q-td>
+    </template>
+    <template #body-cell-publication="p">
+      <q-td :props="p">
+        <router-link
+          :to="{
+            name: 'publication:home',
+            params: { id: p.row.publication.id },
+          }"
+          >{{ p.row.publication.name }}
+        </router-link>
+      </q-td>
+    </template>
+    <template #body-cell-status="p">
+      <q-td :props="p">
+        {{ $t(`submission.status.${p.row.status}`) }}
+      </q-td>
+    </template>
+    <template #body-cell-actions="p">
+      <q-td :props="p">
+        <submission-table-actions
+          :submission="p.row"
+          :action-type="tableType"
+          flat
+        />
+      </q-td>
     </template>
   </q-table>
 </template>

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -16,7 +16,7 @@
             {{ $t(`submission_tables.${role}.title`) }}
           </h3>
           <!-- eslint-disable-next-line vue/no-v-html -->
-          <p class="q-mb-none" v-html="$t(byline)"></p>
+          <p class="q-mb-none" v-html="$t(byline, byline_opts)"></p>
         </div>
         <div class="column">
           <q-select
@@ -49,7 +49,7 @@
     <template #no-data>
       <div class="full-width row flex-center text--grey q-py-lg">
         <p class="text-h3">
-          {{ $t(`submission_tables.${tableType}.no_data`) }}
+          {{ $t(`submission_tables.type.${tableType}.no_data`) }}
         </p>
       </div>
     </template>
@@ -116,6 +116,9 @@ const unique_statuses = computed(() => {
   return unique(props.tableData.map((item) => item.status))
 })
 const byline = `submission_tables.${props.role}.byline`
+const byline_opts = {
+  type_name: t(`submission_tables.type.${props.tableType}.name`),
+}
 const cols = [
   {
     name: "id",

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -1,0 +1,126 @@
+<template>
+  <q-table bordered flat :columns="cols" :rows="tableData" row-key="id" dense>
+    <template #top>
+      <div>
+        <h3 class="q-my-none">{{ tableTitle }}</h3>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <p v-html="tableByline"></p>
+      </div>
+    </template>
+    <template #no-data>
+      <div class="full-width row flex-center text--grey q-py-xl">
+        <p class="text-h3">
+          There are no {{ type == "reviews" ? "reviews" : "submissions" }} for
+          you.
+        </p>
+      </div>
+    </template>
+    <template #body="props">
+      <q-tr :props="props">
+        <q-td key="id" :props="props">
+          {{ props.row.id }}
+        </q-td>
+        <q-td key="title" :props="props">
+          <router-link
+            :to="{
+              name: 'submission_review',
+              params: { id: props.row.id },
+            }"
+            >{{ props.row.title }}
+          </router-link>
+        </q-td>
+        <q-td key="publication" :props="props">
+          <router-link
+            :to="{
+              name: 'publication:home',
+              params: { id: props.row.publication.id },
+            }"
+            >{{ props.row.publication.name }}
+          </router-link>
+        </q-td>
+        <q-td key="status" :props="props">
+          {{ $t(`submission.status.${props.row.status}`) }}
+        </q-td>
+        <q-td key="actions" :props="props">
+          <q-btn flat icon="more_vert">
+            <q-menu anchor="bottom right" self="top right">
+              <q-item
+                clickable
+                :to="{
+                  name: 'submission_details',
+                  params: { id: props.row.id },
+                }"
+                ><q-item-section>Submission Details</q-item-section></q-item
+              >
+              <q-item clickable>
+                <q-item-section data-cy="change_status_item_section">
+                  <q-item-label> Change Status </q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-menu>
+          </q-btn>
+        </q-td>
+      </q-tr>
+    </template>
+  </q-table>
+</template>
+<script setup>
+defineProps({
+  tableData: {
+    type: Array,
+    default: () => [],
+  },
+  tableTitle: {
+    type: String,
+    default: "",
+  },
+  tableByline: {
+    type: String,
+    default: "",
+  },
+  type: {
+    type: String,
+    default: "",
+  },
+})
+const cols = [
+  {
+    name: "id",
+    field: "id",
+    label: "Number",
+    sortable: true,
+    style: "width: 95px",
+    align: "right",
+  },
+  {
+    name: "title",
+    field: "title",
+    label: "Submission Title",
+    sortable: true,
+    align: "left",
+  },
+  {
+    name: "publication",
+    field: "publication",
+    label: "Publication Name",
+    sortable: true,
+    align: "left",
+    style: "width: 10%",
+  },
+  {
+    name: "status",
+    field: "status",
+    label: "Status",
+    sortable: true,
+    align: "center",
+  },
+  {
+    name: "actions",
+    field: "actions",
+    label: "Actions",
+    sortable: false,
+    style: "width: 100px",
+    align: "center",
+  },
+]
+</script>

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -56,7 +56,7 @@
     <template #body="p">
       <q-tr :props="p">
         <q-td key="id" :props="p">
-          {{ props.row.id }}
+          {{ p.row.id }}
         </q-td>
         <q-td key="title" :props="p">
           <router-link

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -6,6 +6,7 @@
     :columns="cols"
     :rows="tableData"
     row-key="id"
+    :filter="status_filter"
     dense
   >
     <template #top>
@@ -18,14 +19,28 @@
         <div class="column">
           <q-select
             v-model="status_filter"
+            clearable
             square
             outlined
             dense
             label="Filter by Status"
-            :options="statuses"
-            style="width: 180px"
+            :options="unique_statuses"
+            style="width: 240px"
             class="q-mt-md q-mr-xs"
-          />
+          >
+            <template #selected-item="scope">
+              {{ $t(`submission.status.${scope.opt}`) }}
+            </template>
+            <template #option="scope">
+              <q-item v-bind="scope.itemProps">
+                <q-item-section>
+                  <q-item-label>
+                    {{ $t(`submission.status.${scope.opt}`) }}
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
+            </template>
+          </q-select>
         </div>
       </div>
     </template>
@@ -64,6 +79,7 @@
           <submission-table-actions
             :submission="props.row"
             action-type="reviews"
+            flat
           />
         </q-td>
       </q-tr>
@@ -73,10 +89,10 @@
 <script setup>
 import SubmissionTableActions from "./SubmissionTableActions.vue"
 import { useI18n } from "vue-i18n"
-import { ref } from "vue"
+import { ref, computed } from "vue"
 const { t } = useI18n()
 
-defineProps({
+const propsVar = defineProps({
   tableData: {
     type: Array,
     default: () => [],
@@ -98,8 +114,11 @@ defineProps({
     default: "reviews.tables.no_data",
   },
 })
-const statuses = ["Initially Submitted", "Under Review"]
 const status_filter = ref(null)
+const unique = (items) => [...new Set(items)]
+const unique_statuses = computed(() => {
+  return unique(propsVar.tableData.map((item) => item.status))
+})
 const cols = [
   {
     name: "id",

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -50,7 +50,7 @@
       </div>
     </template>
     <template #body="props">
-      <q-tr :props="props">
+      <q-tr key="id" :props="props">
         <q-td key="id" :props="props">
           {{ props.row.id }}
         </q-td>

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -9,18 +9,29 @@
     dense
   >
     <template #top>
-      <div>
-        <h3 class="q-my-none">{{ title }}</h3>
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <p v-html="byline"></p>
+      <div class="row full-width justify-between q-pb-md">
+        <div class="column">
+          <h3 class="q-my-none">{{ $t(title) }}</h3>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <p class="q-mb-none" v-html="$t(byline)"></p>
+        </div>
+        <div class="column">
+          <q-select
+            v-model="status_filter"
+            square
+            outlined
+            dense
+            label="Filter by Status"
+            :options="statuses"
+            style="width: 180px"
+            class="q-mt-md q-mr-xs"
+          />
+        </div>
       </div>
     </template>
     <template #no-data>
-      <div class="full-width row flex-center text--grey q-py-xl">
-        <p class="text-h3">
-          There are no
-          {{ tableType == "reviews" ? "reviews" : "submissions" }} for you.
-        </p>
+      <div class="full-width row flex-center text--grey q-py-lg">
+        <p class="text-h3">{{ $t(noData) }}</p>
       </div>
     </template>
     <template #body="props">
@@ -61,6 +72,9 @@
 </template>
 <script setup>
 import SubmissionTableActions from "./SubmissionTableActions.vue"
+import { useI18n } from "vue-i18n"
+import { ref } from "vue"
+const { t } = useI18n()
 
 defineProps({
   tableData: {
@@ -79,12 +93,18 @@ defineProps({
     type: String,
     default: "",
   },
+  noData: {
+    type: String,
+    default: "reviews.tables.no_data",
+  },
 })
+const statuses = ["Initially Submitted", "Under Review"]
+const status_filter = ref(null)
 const cols = [
   {
     name: "id",
     field: "id",
-    label: "Number",
+    label: t(`submission_tables.columns.number`),
     sortable: true,
     style: "width: 95px",
     align: "right",
@@ -92,14 +112,14 @@ const cols = [
   {
     name: "title",
     field: "title",
-    label: "Submission Title",
+    label: t(`submission_tables.columns.title`),
     sortable: true,
     align: "left",
   },
   {
     name: "publication",
     field: "publication",
-    label: "Publication Name",
+    label: t(`submission_tables.columns.publication`),
     sortable: true,
     align: "left",
     style: "width: 10%",
@@ -107,14 +127,14 @@ const cols = [
   {
     name: "status",
     field: "status",
-    label: "Status",
+    label: t(`submission_tables.columns.status`),
     sortable: true,
     align: "center",
   },
   {
     name: "actions",
     field: "actions",
-    label: "Actions",
+    label: t(`submission_tables.columns.actions`),
     sortable: false,
     style: "width: 100px",
     align: "center",

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -23,7 +23,7 @@
             square
             outlined
             dense
-            label="Filter by Status"
+            :label="$t(`submission_tables.filter_label`)"
             :options="unique_statuses"
             style="width: 240px"
             class="q-mt-md q-mr-xs"

--- a/client/src/components/SubmissionTableActions.vue
+++ b/client/src/components/SubmissionTableActions.vue
@@ -1,0 +1,205 @@
+<template>
+  <q-btn
+    data-cy="submission_actions"
+    aria-label="{{$t(submissions.action.toggle_label)}}"
+  >
+    <q-icon name="more_vert" />
+    <q-menu anchor="bottom right" self="top right">
+      <q-item
+        clickable
+        :disable="cannotAccessSubmission(submission)"
+        data-cy="review"
+        :to="destination_to"
+      >
+        <q-item-section>
+          <q-item-label v-if="actionType == 'reviews'">
+            {{ $t("submissions.details_heading") }}
+          </q-item-label>
+          <q-item-label v-else>
+            {{ $t("submissions.action.review.name") }}
+          </q-item-label>
+        </q-item-section>
+        <q-tooltip
+          v-if="cannotAccessSubmission(submission)"
+          anchor="top middle"
+          self="bottom middle"
+          class="text-body1"
+          data-cy="cannot_access_submission_tooltip"
+        >
+          {{ $t("submissions.action.review.no_access") }}
+        </q-tooltip>
+      </q-item>
+      <q-item
+        data-cy="change_status"
+        clickable
+        :disable="
+          submission.status == 'REJECTED' ||
+          submission.status == 'RESUBMISSION_REQUESTED'
+        "
+      >
+        <q-item-section data-cy="change_status_item_section">
+          <q-item-label>
+            {{ $t("submissions.action.change_status.name") }}
+          </q-item-label>
+        </q-item-section>
+        <q-tooltip
+          v-if="
+            submission.status == 'REJECTED' ||
+            submission.status == 'RESUBMISSION_REQUESTED'
+          "
+          anchor="top middle"
+          self="bottom middle"
+          :offset="[10, 10]"
+          class="text-body1"
+          data-cy="cannot_change_submission_status_tooltip"
+        >
+          {{
+            $t(
+              `submissions.action.change_status.no_access.${submission.status}`
+            )
+          }}
+        </q-tooltip>
+
+        <q-item-section side>
+          <q-icon color="accent" name="keyboard_arrow_right" />
+        </q-item-section>
+        <q-menu
+          anchor="bottom end"
+          self="top end"
+          data-cy="change_status_dropdown"
+        >
+          <div v-if="submission.status == 'DRAFT'">
+            <q-item
+              data-cy="initially_submit"
+              class="items-center"
+              clickable
+              @click="confirmHandler('submit_for_review', submission.id)"
+              >{{ $t("submission.action.submit_for_review") }}</q-item
+            >
+          </div>
+          <div
+            v-else-if="
+              submission.status != 'AWAITING_REVIEW' &&
+              submission.status != 'REJECTED' &&
+              submission.status != 'RESUBMISSION_REQUESTED'
+            "
+          >
+            <q-item
+              v-if="submission.status == 'INITIALLY_SUBMITTED'"
+              data-cy="accept_for_review"
+              class="items-center"
+              clickable
+              @click="confirmHandler('accept_for_review', submission.id)"
+              >{{ $t("submission.action.accept_for_review") }}</q-item
+            >
+            <q-item
+              v-if="submission.status != 'INITIALLY_SUBMITTED'"
+              data-cy="accept_as_final"
+              class="items-center"
+              clickable
+              @click="confirmHandler('accept_as_final', submission.id)"
+              >{{ $t("submission.action.accept_as_final") }}</q-item
+            >
+            <q-item
+              class="items-center"
+              clickable
+              @click="confirmHandler('request_resubmission', submission.id)"
+              >{{ $t("submission.action.request_resubmission") }}</q-item
+            >
+            <q-item
+              class="items-center"
+              clickable
+              @click="confirmHandler('reject', submission.id)"
+              >{{ $t("submission.action.reject") }}
+            </q-item>
+          </div>
+          <q-separator />
+          <q-item
+            v-if="submission.status == 'AWAITING_REVIEW'"
+            data-cy="open_review"
+            class="items-center"
+            clickable
+            @click="confirmHandler('open', submission.id)"
+            >{{ $t("submission.action.open") }}
+          </q-item>
+          <q-item
+            v-if="submission.status == 'UNDER_REVIEW'"
+            data-cy="close_review"
+            class="items-center"
+            clickable
+            @click="confirmHandler('close', submission.id)"
+            >{{ $t("submission.action.close") }}
+          </q-item>
+        </q-menu>
+      </q-item>
+    </q-menu>
+  </q-btn>
+</template>
+
+<script setup>
+import ConfirmStatusChangeDialog from "../components/dialogs/ConfirmStatusChangeDialog.vue"
+import { useQuasar } from "quasar"
+import { computed } from "vue"
+const { dialog } = useQuasar()
+
+const props = defineProps({
+  submission: {
+    type: Object,
+    default: () => {},
+  },
+  actionType: {
+    type: String,
+    default: "",
+  },
+})
+
+const destination_to = computed(() => {
+  let to = {
+    name: "submission_review",
+    params: { id: props.submission.id },
+  }
+  if (props.actionType == "reviews") {
+    to = {
+      name: "submission_details",
+      params: { id: props.submission.id },
+    }
+  }
+  return to
+})
+function cannotAccessSubmission(submission) {
+  const nonreviewableStates = new Set([
+    "DRAFT",
+    "INITIALLY_SUBMITTED",
+    "REJECTED",
+    "RESUBMISSION_REQUESTED",
+  ])
+  return (
+    nonreviewableStates.has(submission.status) &&
+    submission.my_role == "reviewer" &&
+    submission.effective_role == "reviewer"
+  )
+}
+async function confirmHandler(action, id) {
+  await new Promise((resolve) => {
+    dirtyDialog(action, id)
+      .onOk(function () {
+        resolve(true)
+      })
+      .onCancel(function () {
+        resolve(false)
+      })
+  })
+  {
+    return
+  }
+}
+function dirtyDialog(action, id) {
+  return dialog({
+    component: ConfirmStatusChangeDialog,
+    componentProps: {
+      action: action,
+      submissionId: id,
+    },
+  })
+}
+</script>

--- a/client/src/components/SubmissionTitle.vue
+++ b/client/src/components/SubmissionTitle.vue
@@ -109,7 +109,9 @@ function checkThatFormIsInvalid() {
   return false
 }
 
-const { mutate } = useMutation(UPDATE_SUBMISSION_TITLE)
+const { mutate } = useMutation(UPDATE_SUBMISSION_TITLE, {
+  refetchQueries: ["GetSubmission"],
+})
 const editing_title = ref(false)
 const submitting_title_edit = ref(false)
 

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -267,13 +267,23 @@ function highlightClickHandler(event) {
   display: block;
   font-family: Helvetica, Arial, san-serif;
   font-size: 1em;
-  margin-right: 10px;
+  left: 0;
+  margin-left: -80px;
   min-width: 50px;
   position: absolute;
-  right: 100%;
   text-align: right;
   top: 0;
   white-space: nowrap;
+}
+
+.submission-content blockquote p:before {
+  // This compensates for the extra padding, border, and margin on blockquotes
+  left: -28px;
+}
+
+.submission-content li p:before {
+  // This compensates for the extra inline padding on lists
+  left: -40px;
 }
 
 mark {

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -73,15 +73,13 @@ export const CURRENT_USER_SUBMISSIONS = gql`
       }
       submissions {
         id
+        title
         status
         my_role
         publication {
           id
+          name
           my_role
-        }
-        pivot {
-          id
-          role_id
         }
       }
     }

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -236,6 +236,7 @@ export const GET_SUBMISSION_REVIEW = gql`
         data
       }
       publication {
+        id
         style_criterias {
           id
           name

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -76,6 +76,7 @@ export const CURRENT_USER_SUBMISSIONS = gql`
         title
         status
         my_role
+        effective_role
         publication {
           id
           name

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -101,6 +101,7 @@
     "menu_button_aria": "Show/hide navigation sidebar",
     "publications": "Publications",
     "submissions": "Submissions",
+    "reviews": "Reviews",
     "user_list": "All Users",
     "notification_button": "View Notifications",
     "application_administration": "Application Administration",
@@ -281,6 +282,9 @@
         }
       }
     }
+  },
+  "reviews": {
+    "page_title": "Reviews"
   },
   "publication": {
     "entity": "Publication | Publications",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -295,19 +295,23 @@
       "status": "Status",
       "actions": "Actions"
     },
-    "reviews": {
-      "no_data": "There are no reviews for you."
-    },
-    "submissions": {
-      "no_data": "There are no submissions for you."
+    "type": {
+      "submissions": {
+        "name": "Submissions",
+        "no_data": "There are no submissions for you."
+      },
+      "reviews": {
+        "name": "Reviews",
+        "no_data": "There are no reviews for you."
+      }
     },
     "reviewer": {
       "title": "To Review",
-      "byline": "Reviews in which you're assigned as a <strong>reviewer</strong>"
+      "byline": "{type_name} in which you're assigned as a <strong>reviewer</strong>"
     },
     "coordinator": {
       "title": "To Coordinate",
-      "byline": "Reviews in which you're assigned as a <strong>review coordinator</strong>"
+      "byline": "{type_name} in which you're assigned as a <strong>review coordinator</strong>"
     }
   },
   "publication": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -296,7 +296,7 @@
     },
     "reviewer": {
       "title": "To Review",
-      "byline": "Reviews in which you're assigned as a reviewer"
+      "byline": "Reviews in which you're assigned as a <strong>reviewer</strong>"
     },
     "coordinator": {
       "title": "To Coordinate",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -286,6 +286,26 @@
   "reviews": {
     "page_title": "Reviews"
   },
+  "submission_tables": {
+    "columns": {
+      "number": "Number",
+      "title": "Submission Title",
+      "publication": "Publication Name",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "reviewer": {
+      "title": "To Review",
+      "byline": "Reviews in which you're assigned as a reviewer"
+    },
+    "coordinator": {
+      "title": "To Coordinate",
+      "byline": "Reviews in which you're assigned as a <strong>review coordinator</strong>"
+    },
+    "no_data": "There is no data.",
+    "no_reviews": "There are no reviews for you.",
+    "no_submissions": "There are no submissions for you."
+  },
   "publication": {
     "entity": "Publication | Publications",
     "configure": "Configure Publication",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -287,12 +287,19 @@
     "page_title": "Reviews"
   },
   "submission_tables": {
+    "filter_label": "Filter by Status",
     "columns": {
       "number": "Number",
       "title": "Submission Title",
       "publication": "Publication Name",
       "status": "Status",
       "actions": "Actions"
+    },
+    "reviews": {
+      "no_data": "There are no reviews for you."
+    },
+    "submissions": {
+      "no_data": "There are no submissions for you."
     },
     "reviewer": {
       "title": "To Review",
@@ -301,11 +308,7 @@
     "coordinator": {
       "title": "To Coordinate",
       "byline": "Reviews in which you're assigned as a <strong>review coordinator</strong>"
-    },
-    "no_data": "There is no data.",
-    "no_reviews": "There are no reviews for you.",
-    "no_submissions": "There are no submissions for you.",
-    "filter_label": "Filter by Status"
+    }
   },
   "publication": {
     "entity": "Publication | Publications",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -304,7 +304,8 @@
     },
     "no_data": "There is no data.",
     "no_reviews": "There are no reviews for you.",
-    "no_submissions": "There are no submissions for you."
+    "no_submissions": "There are no submissions for you.",
+    "filter_label": "Filter by Status"
   },
   "publication": {
     "entity": "Publication | Publications",

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -6,18 +6,6 @@ import { createMockClient } from "mock-apollo-client"
 import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
 import flushPromises from "flush-promises"
 
-jest.mock("quasar", () => ({
-  ...jest.requireActual("quasar"),
-  useQuasar: () => ({
-    notify: jest.fn(),
-  }),
-}))
-jest.mock("vue-i18n", () => ({
-  useI18n: () => ({
-    t: (t) => t,
-  }),
-}))
-
 installQuasarPlugin()
 describe("Reviews Page", () => {
   const mockClient = createMockClient()
@@ -159,8 +147,8 @@ describe("Reviews Page", () => {
       },
     })
     const wrapper = await makeWrapper()
-    expect(
-      wrapper.findAllComponents({ name: "submission-table" })
-    ).toHaveLength(1)
+    expect(wrapper.findAllComponents({ name: "submission-table" }).length).toBe(
+      1
+    )
   })
 })

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -1,0 +1,105 @@
+import { mount } from "@vue/test-utils"
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest"
+import ReviewsPage from "./ReviewsPage.vue"
+import { ApolloClients } from "@vue/apollo-composable"
+import { createMockClient } from "mock-apollo-client"
+import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
+import flushPromises from "flush-promises"
+
+jest.mock("quasar", () => ({
+  ...jest.requireActual("quasar"),
+  useQuasar: () => ({
+    notify: jest.fn(),
+  }),
+}))
+jest.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (t) => t,
+  }),
+}))
+
+installQuasarPlugin()
+describe("Reviews Page", () => {
+  const mockClient = createMockClient()
+  const makeWrapper = async () => {
+    const wrapper = mount(ReviewsPage, {
+      global: {
+        provide: {
+          [ApolloClients]: { default: mockClient },
+        },
+        stubs: ["router-link"],
+        mocks: {
+          $t: (token) => token,
+        },
+      },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  const CurrentUserSubmissions = jest.fn()
+  mockClient.setRequestHandler(CURRENT_USER_SUBMISSIONS, CurrentUserSubmissions)
+
+  test("all reviews appear within the list", async () => {
+    CurrentUserSubmissions.mockResolvedValue({
+      data: {
+        submissions: {
+          paginatorInfo: {
+            __typename: "PaginatorInfo",
+            count: 5,
+            currentPage: 1,
+            lastPage: 1,
+            perPage: 10,
+          },
+          data: [
+            {
+              id: "1",
+              title: "Jest Submission 1",
+              status: "INITIALLY_SUBMITTED",
+              my_role: "submitter",
+              publication: { name: "Jest Publication" },
+              files: [],
+            },
+            {
+              id: "2",
+              title: "Jest Submission 2",
+              status: "RESUBMISSION_REQUESTED",
+              my_role: "reviewer",
+              publication: { name: "Jest Publication" },
+              files: [],
+            },
+            {
+              id: "3",
+              title: "Jest Submission 3",
+              status: "AWAITING_REVIEW",
+              my_role: "review_coordinator",
+              effective_role: "review_coordinator",
+              publication: { name: "Jest Publication" },
+              files: [],
+            },
+            {
+              id: "4",
+              title: "Jest Submission 4",
+              status: "REJECTED",
+              my_role: "",
+              effective_role: "review_coordinator",
+              publication: { name: "Jest Publication" },
+              files: [],
+            },
+            {
+              id: "5",
+              title: "Jest Submission 5",
+              status: "INITIALLY_SUBMITTED",
+              my_role: "",
+              effective_role: "",
+              publication: { name: "Jest Publication" },
+              files: [],
+            },
+          ],
+        },
+      },
+    })
+    const wrapper = await makeWrapper()
+    expect(wrapper.findAllComponents({ name: "q-item" })).toHaveLength(5)
+  })
+})

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -6,17 +6,6 @@ import { createMockClient } from "mock-apollo-client"
 import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
 import flushPromises from "flush-promises"
 import { InMemoryCache } from "@apollo/client/core"
-jest.mock("quasar", () => ({
-  ...jest.requireActual("quasar"),
-  useQuasar: () => ({
-    notify: jest.fn(),
-  }),
-}))
-jest.mock("vue-i18n", () => ({
-  useI18n: () => ({
-    t: (t) => t,
-  }),
-}))
 
 installQuasarPlugin()
 describe("Reviews Page", () => {
@@ -46,7 +35,7 @@ describe("Reviews Page", () => {
   const CurrentUserSubmissions = jest.fn()
   mockClient.setRequestHandler(CURRENT_USER_SUBMISSIONS, CurrentUserSubmissions)
 
-  test("all submission tables appear for a user as a review coordinator", async () => {
+  test("two submission tables appear for a user as a review coordinator", async () => {
     CurrentUserSubmissions.mockResolvedValue({
       data: {
         currentUser: {

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -40,33 +40,38 @@ describe("Reviews Page", () => {
   const CurrentUserSubmissions = jest.fn()
   mockClient.setRequestHandler(CURRENT_USER_SUBMISSIONS, CurrentUserSubmissions)
 
-  test("all reviews appear within the list", async () => {
+  test("all submission tables appear for a user as a review coordinator", async () => {
     CurrentUserSubmissions.mockResolvedValue({
       data: {
-        submissions: {
-          paginatorInfo: {
-            __typename: "PaginatorInfo",
-            count: 5,
-            currentPage: 1,
-            lastPage: 1,
-            perPage: 10,
+        currentUser: {
+          id: 1000,
+          roles: {
+            name: "Application Administrator",
           },
-          data: [
+          submissions: [
             {
               id: "1",
               title: "Jest Submission 1",
               status: "INITIALLY_SUBMITTED",
               my_role: "submitter",
-              publication: { name: "Jest Publication" },
-              files: [],
+              effective_role: "submitter",
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
             },
             {
               id: "2",
               title: "Jest Submission 2",
               status: "RESUBMISSION_REQUESTED",
               my_role: "reviewer",
-              publication: { name: "Jest Publication" },
-              files: [],
+              effective_role: "reviewer",
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
             },
             {
               id: "3",
@@ -74,32 +79,88 @@ describe("Reviews Page", () => {
               status: "AWAITING_REVIEW",
               my_role: "review_coordinator",
               effective_role: "review_coordinator",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
             },
             {
               id: "4",
               title: "Jest Submission 4",
               status: "REJECTED",
-              my_role: "",
+              my_role: "review_coordinator",
               effective_role: "review_coordinator",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
             },
             {
               id: "5",
               title: "Jest Submission 5",
               status: "INITIALLY_SUBMITTED",
-              my_role: "",
-              effective_role: "",
-              publication: { name: "Jest Publication" },
-              files: [],
+              my_role: "reviewer",
+              effective_role: "reviewer",
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    const wrapper = await makeWrapper()
+    expect(
+      wrapper.findAllComponents({ name: "submission-table" })
+    ).toHaveLength(2)
+    CurrentUserSubmissions.mockClear()
+  })
+
+  test("only one submission table appears for a user as a reviewer", async () => {
+    CurrentUserSubmissions.mockResolvedValue({
+      data: {
+        currentUser: {
+          id: 1000,
+          roles: {
+            name: "Application Administrator",
+          },
+          submissions: [
+            {
+              id: "1",
+              title: "Jest Submission 1",
+              status: "INITIALLY_SUBMITTED",
+              my_role: "submitter",
+              effective_role: "submitter",
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
+            },
+            {
+              id: "2",
+              title: "Jest Submission 2",
+              status: "RESUBMISSION_REQUESTED",
+              my_role: "reviewer",
+              effective_role: "reviewer",
+              publication: {
+                id: "1",
+                name: "Jest Publication",
+                my_role: null,
+              },
             },
           ],
         },
       },
     })
     const wrapper = await makeWrapper()
-    expect(wrapper.findAllComponents({ name: "q-item" })).toHaveLength(5)
+    expect(
+      wrapper.findAllComponents({ name: "submission-table" })
+    ).toHaveLength(1)
   })
 })

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -5,10 +5,28 @@ import { ApolloClients } from "@vue/apollo-composable"
 import { createMockClient } from "mock-apollo-client"
 import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
 import flushPromises from "flush-promises"
+import { InMemoryCache } from "@apollo/client/core"
+jest.mock("quasar", () => ({
+  ...jest.requireActual("quasar"),
+  useQuasar: () => ({
+    notify: jest.fn(),
+  }),
+}))
+jest.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (t) => t,
+  }),
+}))
 
 installQuasarPlugin()
 describe("Reviews Page", () => {
-  const mockClient = createMockClient()
+  const cache = new InMemoryCache({
+    addTypename: true,
+  })
+  const mockClient = createMockClient({
+    defaultOptions: { watchQuery: { fetchPolicy: "network-only" } },
+    cache,
+  })
   const makeWrapper = async () => {
     const wrapper = mount(ReviewsPage, {
       global: {

--- a/client/src/pages/ReviewsPage.jest.spec.js
+++ b/client/src/pages/ReviewsPage.jest.spec.js
@@ -110,10 +110,9 @@ describe("Reviews Page", () => {
     })
 
     const wrapper = await makeWrapper()
-    expect(
-      wrapper.findAllComponents({ name: "submission-table" })
-    ).toHaveLength(2)
-    CurrentUserSubmissions.mockClear()
+    expect(wrapper.findAllComponents({ name: "submission-table" }).length).toBe(
+      2
+    )
   })
 
   test("only one submission table appears for a user as a reviewer", async () => {

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -3,11 +3,7 @@
     <h2 class="q-pl-lg">{{ $t(`reviews.page_title`) }}</h2>
     <div class="row q-col-gutter-lg q-pa-lg">
       <section class="col-md-10 col-sm-11 col-xs-12">
-        <submission-table
-          :table-data="reviewer_reviews"
-          table-type="reviews"
-          role="reviewer"
-        />
+        <submission-table :table-data="reviewer_reviews" table-type="reviews" />
       </section>
       <section class="col-md-10 col-sm-11 col-xs-12 q-mt-md">
         <submission-table

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -5,19 +5,19 @@
       <section class="col-md-10 col-sm-11 col-xs-12">
         <submission-table
           :table-data="reviewer_reviews"
-          table-title="To Review"
-          table-byline="Reviews in which you're assigned as a <strong>reviewer</strong>"
-          type="reviews"
+          title="To Review"
+          byline="Reviews in which you're assigned as a <strong>reviewer</strong>"
+          table-type="reviews"
         />
       </section>
       <section class="col-md-10 col-sm-11 col-xs-12 q-mt-lg">
         <submission-table
           v-if="coordinator_reviews.length > 0"
           :table-data="coordinator_reviews"
-          table-title="To Coordinate"
-          table-byline="Reviews in which you're assigned as a
+          title="To Coordinate"
+          byline="Reviews in which you're assigned as a
         <strong>review coordinator</strong>"
-          type="reviews"
+          table-type="reviews"
         />
       </section>
     </div>
@@ -39,6 +39,7 @@ const reviewer_reviews = computed(() =>
     return (
       submission.status != "DRAFT" &&
       submission.status != "INITIALLY_SUBMITTED" &&
+      submission.status != "AWAITING_REVIEW" &&
       submission.my_role == "reviewer"
     )
   })
@@ -46,9 +47,7 @@ const reviewer_reviews = computed(() =>
 const coordinator_reviews = computed(() =>
   submissions.value.filter(function (submission) {
     return (
-      submission.status != "DRAFT" &&
-      submission.status != "INITIALLY_SUBMITTED" &&
-      submission.my_role == "review_coordinator"
+      submission.status != "DRAFT" && submission.my_role == "review_coordinator"
     )
   })
 )

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -13,7 +13,7 @@
       </section>
       <section class="col-md-10 col-sm-11 col-xs-12 q-mt-md">
         <submission-table
-          v-if="coordinator_submission_length > 0"
+          v-if="coordinator_reviews.length > 0"
           :table-data="coordinator_reviews"
           title="submission_tables.coordinator.title"
           byline="submission_tables.coordinator.byline"

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -5,20 +5,16 @@
       <section class="col-md-10 col-sm-11 col-xs-12">
         <submission-table
           :table-data="reviewer_reviews"
-          title="submission_tables.reviewer.title"
-          byline="submission_tables.reviewer.byline"
-          no-data="submission_tables.no_reviews"
           table-type="reviews"
+          role="reviewer"
         />
       </section>
       <section class="col-md-10 col-sm-11 col-xs-12 q-mt-md">
         <submission-table
           v-if="coordinator_reviews.length > 0"
           :table-data="coordinator_reviews"
-          title="submission_tables.coordinator.title"
-          byline="submission_tables.coordinator.byline"
-          no-data="submission_tables.no_reviews"
           table-type="reviews"
+          role="coordinator"
         />
       </section>
     </div>

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -2,56 +2,212 @@
   <article>
     <h2 class="q-pl-lg">{{ $t(`reviews.page_title`) }}</h2>
     <div class="row q-col-gutter-lg q-pa-lg">
-      <section class="col-md-7 col-sm-6 col-xs-12">
-        <p>Reviews where you are assigned as a submitter</p>
+      <section class="col-md-10 col-sm-11 col-xs-12">
         <q-table
-          title="To Collaborate"
+          bordered
+          flat
           :columns="cols"
-          :rows="rows_none"
-          row-key="name"
+          :rows="reviewer_reviews"
+          row-key="id"
+          dense
         >
-          <template #header>
-            <h3>Title</h3>
+          <template #top>
+            <div>
+              <h3 class="q-my-none">To Review</h3>
+              <p>
+                Reviews in which you're assigned as a <strong>reviewer</strong>
+              </p>
+            </div>
+          </template>
+          <template #body="props">
+            <q-tr :props="props">
+              <q-td key="id" :props="props">
+                {{ props.row.id }}
+              </q-td>
+              <q-td key="title" :props="props">
+                <router-link
+                  :to="{
+                    name: 'submission_review',
+                    params: { id: props.row.id },
+                  }"
+                  >{{ props.row.title }}
+                </router-link>
+              </q-td>
+              <q-td key="publication" :props="props">
+                <router-link
+                  :to="{
+                    name: 'publication:home',
+                    params: { id: props.row.publication.id },
+                  }"
+                  >{{ props.row.publication.name }}
+                </router-link>
+              </q-td>
+              <q-td key="status" :props="props">
+                {{ $t(`submission.status.${props.row.status}`) }}
+              </q-td>
+              <q-td key="actions" :props="props">
+                <q-btn flat icon="more_vert">
+                  <q-menu anchor="bottom right" self="top right">
+                    <q-item
+                      clickable
+                      :to="{
+                        name: 'submission_details',
+                        params: { id: props.row.id },
+                      }"
+                      ><q-item-section
+                        >Submission Details</q-item-section
+                      ></q-item
+                    >
+                    <q-item clickable>
+                      <q-item-section data-cy="change_status_item_section">
+                        <q-item-label> Change Status </q-item-label>
+                      </q-item-section>
+                    </q-item>
+                  </q-menu>
+                </q-btn>
+              </q-td>
+            </q-tr>
           </template>
         </q-table>
       </section>
-      <section class="col-md-7 col-sm-6 col-xs-12">
-        <h3>To Review</h3>
-        <p>Reviews where you are assigned as a reviewer</p>
+      <section class="col-md-10 col-sm-11 col-xs-12 q-mt-lg">
         <q-table
-          title="To Review"
-          :rows="rows"
+          v-if="coordinator_reviews.length > 0"
+          bordered
+          flat
           :columns="cols"
-          row-key="name"
-        />
-      </section>
-      <section class="col-md-7 col-sm-6 col-xs-12">
-        <h3>To Coordinate</h3>
-        <p>Reviews where you are assigned as a review coordinator</p>
-        <q-table />
+          :rows="coordinator_reviews"
+          row-key="id"
+          dense
+        >
+          <template #top>
+            <div>
+              <h3 class="q-my-none">To Coordinate</h3>
+              <p>
+                Reviews in which you're assigned as a
+                <strong>review coordinator</strong>
+              </p>
+            </div>
+          </template>
+          <template #body="props">
+            <q-tr :props="props">
+              <q-td key="id" :props="props">
+                {{ props.row.id }}
+              </q-td>
+              <q-td key="title" :props="props">
+                <router-link
+                  :to="{
+                    name: 'submission_review',
+                    params: { id: props.row.id },
+                  }"
+                  >{{ props.row.title }}
+                </router-link>
+              </q-td>
+              <q-td key="publication" :props="props">
+                <router-link
+                  :to="{
+                    name: 'publication:home',
+                    params: { id: props.row.publication.id },
+                  }"
+                  >{{ props.row.publication.name }}
+                </router-link>
+              </q-td>
+              <q-td key="status" :props="props">
+                {{ $t(`submission.status.${props.row.status}`) }}
+              </q-td>
+              <q-td key="actions" :props="props">
+                <q-btn flat icon="more_vert">
+                  <q-menu anchor="bottom right" self="top right">
+                    <q-item
+                      clickable
+                      :to="{
+                        name: 'submission_details',
+                        params: { id: props.row.id },
+                      }"
+                      ><q-item-section
+                        >Submission Details</q-item-section
+                      ></q-item
+                    >
+                    <q-item clickable>
+                      <q-item-section data-cy="change_status_item_section">
+                        <q-item-label> Change Status </q-item-label>
+                      </q-item-section>
+                    </q-item>
+                  </q-menu>
+                </q-btn>
+              </q-td>
+            </q-tr>
+          </template>
+        </q-table>
       </section>
     </div>
   </article>
 </template>
 
 <script setup>
+import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
+import { useQuery } from "@vue/apollo-composable"
+import { computed } from "vue"
+const { result } = useQuery(CURRENT_USER_SUBMISSIONS)
+const submissions = computed(() => {
+  return result.value?.currentUser?.submissions ?? []
+})
+const reviewer_reviews = computed(() =>
+  submissions.value.filter(function (submission) {
+    return (
+      submission.status != "DRAFT" &&
+      submission.status != "INITIALLY_SUBMITTED" &&
+      submission.my_role == "reviewer"
+    )
+  })
+)
+const coordinator_reviews = computed(() =>
+  submissions.value.filter(function (submission) {
+    return (
+      submission.status != "DRAFT" &&
+      submission.status != "INITIALLY_SUBMITTED" &&
+      submission.my_role == "review_coordinator"
+    )
+  })
+)
 const cols = [
   {
     name: "id",
+    field: "id",
     label: "Number",
     sortable: true,
+    style: "width: 95px",
+    align: "right",
   },
   {
-    name: "submission",
-    label: "Submission",
+    name: "title",
+    field: "title",
+    label: "Submission Title",
     sortable: true,
+    align: "left",
   },
-]
-const rows = [
   {
-    id: 20,
-    submission: "My Big Proposal",
+    name: "publication",
+    field: "publication",
+    label: "Publication Name",
+    sortable: true,
+    align: "left",
+    style: "width: 10%",
+  },
+  {
+    name: "status",
+    field: "status",
+    label: "Status",
+    sortable: true,
+    align: "center",
+  },
+  {
+    name: "actions",
+    field: "actions",
+    label: "Actions",
+    sortable: false,
+    style: "width: 100px",
+    align: "center",
   },
 ]
-const rows_none = []
 </script>

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -1,0 +1,57 @@
+<template>
+  <article>
+    <h2 class="q-pl-lg">{{ $t(`reviews.page_title`) }}</h2>
+    <div class="row q-col-gutter-lg q-pa-lg">
+      <section class="col-md-7 col-sm-6 col-xs-12">
+        <p>Reviews where you are assigned as a submitter</p>
+        <q-table
+          title="To Collaborate"
+          :columns="cols"
+          :rows="rows_none"
+          row-key="name"
+        >
+          <template #header>
+            <h3>Title</h3>
+          </template>
+        </q-table>
+      </section>
+      <section class="col-md-7 col-sm-6 col-xs-12">
+        <h3>To Review</h3>
+        <p>Reviews where you are assigned as a reviewer</p>
+        <q-table
+          title="To Review"
+          :rows="rows"
+          :columns="cols"
+          row-key="name"
+        />
+      </section>
+      <section class="col-md-7 col-sm-6 col-xs-12">
+        <h3>To Coordinate</h3>
+        <p>Reviews where you are assigned as a review coordinator</p>
+        <q-table />
+      </section>
+    </div>
+  </article>
+</template>
+
+<script setup>
+const cols = [
+  {
+    name: "id",
+    label: "Number",
+    sortable: true,
+  },
+  {
+    name: "submission",
+    label: "Submission",
+    sortable: true,
+  },
+]
+const rows = [
+  {
+    id: 20,
+    submission: "My Big Proposal",
+  },
+]
+const rows_none = []
+</script>

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -3,142 +3,22 @@
     <h2 class="q-pl-lg">{{ $t(`reviews.page_title`) }}</h2>
     <div class="row q-col-gutter-lg q-pa-lg">
       <section class="col-md-10 col-sm-11 col-xs-12">
-        <q-table
-          bordered
-          flat
-          :columns="cols"
-          :rows="reviewer_reviews"
-          row-key="id"
-          dense
-        >
-          <template #top>
-            <div>
-              <h3 class="q-my-none">To Review</h3>
-              <p>
-                Reviews in which you're assigned as a <strong>reviewer</strong>
-              </p>
-            </div>
-          </template>
-          <template #body="props">
-            <q-tr :props="props">
-              <q-td key="id" :props="props">
-                {{ props.row.id }}
-              </q-td>
-              <q-td key="title" :props="props">
-                <router-link
-                  :to="{
-                    name: 'submission_review',
-                    params: { id: props.row.id },
-                  }"
-                  >{{ props.row.title }}
-                </router-link>
-              </q-td>
-              <q-td key="publication" :props="props">
-                <router-link
-                  :to="{
-                    name: 'publication:home',
-                    params: { id: props.row.publication.id },
-                  }"
-                  >{{ props.row.publication.name }}
-                </router-link>
-              </q-td>
-              <q-td key="status" :props="props">
-                {{ $t(`submission.status.${props.row.status}`) }}
-              </q-td>
-              <q-td key="actions" :props="props">
-                <q-btn flat icon="more_vert">
-                  <q-menu anchor="bottom right" self="top right">
-                    <q-item
-                      clickable
-                      :to="{
-                        name: 'submission_details',
-                        params: { id: props.row.id },
-                      }"
-                      ><q-item-section
-                        >Submission Details</q-item-section
-                      ></q-item
-                    >
-                    <q-item clickable>
-                      <q-item-section data-cy="change_status_item_section">
-                        <q-item-label> Change Status </q-item-label>
-                      </q-item-section>
-                    </q-item>
-                  </q-menu>
-                </q-btn>
-              </q-td>
-            </q-tr>
-          </template>
-        </q-table>
+        <submission-table
+          :table-data="reviewer_reviews"
+          table-title="To Review"
+          table-byline="Reviews in which you're assigned as a <strong>reviewer</strong>"
+          type="reviews"
+        />
       </section>
       <section class="col-md-10 col-sm-11 col-xs-12 q-mt-lg">
-        <q-table
+        <submission-table
           v-if="coordinator_reviews.length > 0"
-          bordered
-          flat
-          :columns="cols"
-          :rows="coordinator_reviews"
-          row-key="id"
-          dense
-        >
-          <template #top>
-            <div>
-              <h3 class="q-my-none">To Coordinate</h3>
-              <p>
-                Reviews in which you're assigned as a
-                <strong>review coordinator</strong>
-              </p>
-            </div>
-          </template>
-          <template #body="props">
-            <q-tr :props="props">
-              <q-td key="id" :props="props">
-                {{ props.row.id }}
-              </q-td>
-              <q-td key="title" :props="props">
-                <router-link
-                  :to="{
-                    name: 'submission_review',
-                    params: { id: props.row.id },
-                  }"
-                  >{{ props.row.title }}
-                </router-link>
-              </q-td>
-              <q-td key="publication" :props="props">
-                <router-link
-                  :to="{
-                    name: 'publication:home',
-                    params: { id: props.row.publication.id },
-                  }"
-                  >{{ props.row.publication.name }}
-                </router-link>
-              </q-td>
-              <q-td key="status" :props="props">
-                {{ $t(`submission.status.${props.row.status}`) }}
-              </q-td>
-              <q-td key="actions" :props="props">
-                <q-btn flat icon="more_vert">
-                  <q-menu anchor="bottom right" self="top right">
-                    <q-item
-                      clickable
-                      :to="{
-                        name: 'submission_details',
-                        params: { id: props.row.id },
-                      }"
-                      ><q-item-section
-                        >Submission Details</q-item-section
-                      ></q-item
-                    >
-                    <q-item clickable>
-                      <q-item-section data-cy="change_status_item_section">
-                        <q-item-label> Change Status </q-item-label>
-                      </q-item-section>
-                    </q-item>
-                  </q-menu>
-                </q-btn>
-              </q-td>
-            </q-tr>
-          </template>
-        </q-table>
+          :table-data="coordinator_reviews"
+          table-title="To Coordinate"
+          table-byline="Reviews in which you're assigned as a
+        <strong>review coordinator</strong>"
+          type="reviews"
+        />
       </section>
     </div>
   </article>
@@ -148,6 +28,8 @@
 import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
 import { useQuery } from "@vue/apollo-composable"
 import { computed } from "vue"
+import SubmissionTable from "src/components/SubmissionTable.vue"
+
 const { result } = useQuery(CURRENT_USER_SUBMISSIONS)
 const submissions = computed(() => {
   return result.value?.currentUser?.submissions ?? []
@@ -170,44 +52,4 @@ const coordinator_reviews = computed(() =>
     )
   })
 )
-const cols = [
-  {
-    name: "id",
-    field: "id",
-    label: "Number",
-    sortable: true,
-    style: "width: 95px",
-    align: "right",
-  },
-  {
-    name: "title",
-    field: "title",
-    label: "Submission Title",
-    sortable: true,
-    align: "left",
-  },
-  {
-    name: "publication",
-    field: "publication",
-    label: "Publication Name",
-    sortable: true,
-    align: "left",
-    style: "width: 10%",
-  },
-  {
-    name: "status",
-    field: "status",
-    label: "Status",
-    sortable: true,
-    align: "center",
-  },
-  {
-    name: "actions",
-    field: "actions",
-    label: "Actions",
-    sortable: false,
-    style: "width: 100px",
-    align: "center",
-  },
-]
 </script>

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -38,8 +38,9 @@ const submissions = computed(() => {
 const reviewer_reviews = computed(() =>
   submissions.value.filter(function (submission) {
     return (
-      ["DRAFT", "INITIALLY_SUBMITTED", "AWAITING_REVIEW"].includes(submission.status) === false &&
-      submission.my_role == "reviewer"
+      ["DRAFT", "INITIALLY_SUBMITTED", "AWAITING_REVIEW"].includes(
+        submission.status
+      ) === false && submission.my_role == "reviewer"
     )
   })
 )

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -5,18 +5,19 @@
       <section class="col-md-10 col-sm-11 col-xs-12">
         <submission-table
           :table-data="reviewer_reviews"
-          title="To Review"
-          byline="Reviews in which you're assigned as a <strong>reviewer</strong>"
+          title="submission_tables.reviewer.title"
+          byline="submission_tables.reviewer.byline"
+          no-data="submission_tables.no_reviews"
           table-type="reviews"
         />
       </section>
-      <section class="col-md-10 col-sm-11 col-xs-12 q-mt-lg">
+      <section class="col-md-10 col-sm-11 col-xs-12 q-mt-md">
         <submission-table
-          v-if="coordinator_reviews.length > 0"
+          v-if="coordinator_submission_length > 0"
           :table-data="coordinator_reviews"
-          title="To Coordinate"
-          byline="Reviews in which you're assigned as a
-        <strong>review coordinator</strong>"
+          title="submission_tables.coordinator.title"
+          byline="submission_tables.coordinator.byline"
+          no-data="submission_tables.no_reviews"
           table-type="reviews"
         />
       </section>

--- a/client/src/pages/ReviewsPage.vue
+++ b/client/src/pages/ReviewsPage.vue
@@ -38,9 +38,7 @@ const submissions = computed(() => {
 const reviewer_reviews = computed(() =>
   submissions.value.filter(function (submission) {
     return (
-      submission.status != "DRAFT" &&
-      submission.status != "INITIALLY_SUBMITTED" &&
-      submission.status != "AWAITING_REVIEW" &&
+      ["DRAFT", "INITIALLY_SUBMITTED", "AWAITING_REVIEW"].includes(submission.status) === false &&
       submission.my_role == "reviewer"
     )
   })

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -99,158 +99,7 @@
               </q-item-label>
             </q-item-section>
             <div class="q-gutter-sm submission-options">
-              <q-btn
-                data-cy="submission_actions"
-                aria-label="{{$t(submissions.action.toggle_label)}}"
-              >
-                <q-icon name="more_vert" />
-                <q-menu anchor="bottom right" self="top right">
-                  <q-item
-                    clickable
-                    :disable="cannotAccessSubmission(submission)"
-                    data-cy="review"
-                    :to="{
-                      name: 'submission_review',
-                      params: { id: submission.id },
-                    }"
-                  >
-                    <q-item-section>
-                      <q-item-label>
-                        {{ $t("submissions.action.review.name") }}
-                      </q-item-label>
-                    </q-item-section>
-                    <q-tooltip
-                      v-if="cannotAccessSubmission(submission)"
-                      anchor="top middle"
-                      self="bottom middle"
-                      class="text-body1"
-                      data-cy="cannot_access_submission_tooltip"
-                    >
-                      {{ $t("submissions.action.review.no_access") }}
-                    </q-tooltip>
-                  </q-item>
-                  <q-item
-                    data-cy="change_status"
-                    clickable
-                    :disable="
-                      submission.status == 'REJECTED' ||
-                      submission.status == 'RESUBMISSION_REQUESTED'
-                    "
-                  >
-                    <q-item-section data-cy="change_status_item_section">
-                      <q-item-label>
-                        {{ $t("submissions.action.change_status.name") }}
-                      </q-item-label>
-                    </q-item-section>
-                    <q-tooltip
-                      v-if="
-                        submission.status == 'REJECTED' ||
-                        submission.status == 'RESUBMISSION_REQUESTED'
-                      "
-                      anchor="top middle"
-                      self="bottom middle"
-                      :offset="[10, 10]"
-                      class="text-body1"
-                      data-cy="cannot_change_submission_status_tooltip"
-                    >
-                      {{
-                        $t(
-                          `submissions.action.change_status.no_access.${submission.status}`
-                        )
-                      }}
-                    </q-tooltip>
-
-                    <q-item-section side>
-                      <q-icon color="accent" name="keyboard_arrow_right" />
-                    </q-item-section>
-                    <q-menu
-                      anchor="bottom end"
-                      self="top end"
-                      data-cy="change_status_dropdown"
-                    >
-                      <div v-if="submission.status == 'DRAFT'">
-                        <q-item
-                          data-cy="initially_submit"
-                          class="items-center"
-                          clickable
-                          @click="
-                            confirmHandler('submit_for_review', submission.id)
-                          "
-                          >{{
-                            $t("submission.action.submit_for_review")
-                          }}</q-item
-                        >
-                      </div>
-                      <div
-                        v-else-if="
-                          submission.status != 'AWAITING_REVIEW' &&
-                          submission.status != 'REJECTED' &&
-                          submission.status != 'RESUBMISSION_REQUESTED'
-                        "
-                      >
-                        <q-item
-                          v-if="submission.status == 'INITIALLY_SUBMITTED'"
-                          data-cy="accept_for_review"
-                          class="items-center"
-                          clickable
-                          @click="
-                            confirmHandler('accept_for_review', submission.id)
-                          "
-                          >{{
-                            $t("submission.action.accept_for_review")
-                          }}</q-item
-                        >
-                        <q-item
-                          v-if="submission.status != 'INITIALLY_SUBMITTED'"
-                          data-cy="accept_as_final"
-                          class="items-center"
-                          clickable
-                          @click="
-                            confirmHandler('accept_as_final', submission.id)
-                          "
-                          >{{ $t("submission.action.accept_as_final") }}</q-item
-                        >
-                        <q-item
-                          class="items-center"
-                          clickable
-                          @click="
-                            confirmHandler(
-                              'request_resubmission',
-                              submission.id
-                            )
-                          "
-                          >{{
-                            $t("submission.action.request_resubmission")
-                          }}</q-item
-                        >
-                        <q-item
-                          class="items-center"
-                          clickable
-                          @click="confirmHandler('reject', submission.id)"
-                          >{{ $t("submission.action.reject") }}
-                        </q-item>
-                      </div>
-                      <q-separator />
-                      <q-item
-                        v-if="submission.status == 'AWAITING_REVIEW'"
-                        data-cy="open_review"
-                        class="items-center"
-                        clickable
-                        @click="confirmHandler('open', submission.id)"
-                        >{{ $t("submission.action.open") }}
-                      </q-item>
-                      <q-item
-                        v-if="submission.status == 'UNDER_REVIEW'"
-                        data-cy="close_review"
-                        class="items-center"
-                        clickable
-                        @click="confirmHandler('close', submission.id)"
-                        >{{ $t("submission.action.close") }}
-                      </q-item>
-                    </q-menu>
-                  </q-item>
-                </q-menu>
-              </q-btn>
+              <submission-table-actions :submission="submission" />
             </div>
           </q-item>
         </q-list>
@@ -278,26 +127,9 @@ import { useI18n } from "vue-i18n"
 import { ref, reactive, computed } from "vue"
 import { useQuery, useMutation } from "@vue/apollo-composable"
 import useVuelidate from "@vuelidate/core"
-import ConfirmStatusChangeDialog from "../components/dialogs/ConfirmStatusChangeDialog.vue"
-import { useQuasar } from "quasar"
-
-const { dialog } = useQuasar()
+import SubmissionTableActions from "../components/SubmissionTableActions.vue"
 
 const { currentUser } = useCurrentUser()
-
-function cannotAccessSubmission(submission) {
-  const nonreviewableStates = new Set([
-    "DRAFT",
-    "INITIALLY_SUBMITTED",
-    "REJECTED",
-    "RESUBMISSION_REQUESTED",
-  ])
-  return (
-    nonreviewableStates.has(submission.status) &&
-    submission.my_role == "reviewer" &&
-    submission.effective_role == "reviewer"
-  )
-}
 
 function includeDraftSubmissions(submission) {
   return (
@@ -395,29 +227,5 @@ async function createNewSubmission() {
   function resetForm() {
     Object.assign(new_submission, { title: "", file_upload: [] })
   }
-}
-
-async function confirmHandler(action, id) {
-  await new Promise((resolve) => {
-    dirtyDialog(action, id)
-      .onOk(function () {
-        resolve(true)
-      })
-      .onCancel(function () {
-        resolve(false)
-      })
-  })
-  {
-    return
-  }
-}
-function dirtyDialog(action, id) {
-  return dialog({
-    component: ConfirmStatusChangeDialog,
-    componentProps: {
-      action: action,
-      submissionId: id,
-    },
-  })
 }
 </script>

--- a/client/src/router/routes.js
+++ b/client/src/router/routes.js
@@ -118,6 +118,10 @@ const routes = [
         props: true,
       },
       {
+        path: "/reviews",
+        component: () => import("src/pages/ReviewsPage.vue"),
+      },
+      {
         path: "/submissions",
         component: () => import("src/pages/SubmissionsPage.vue"),
       },


### PR DESCRIPTION
This pull request:

* Adds a new "Reviews" page
    * Shows a list of reviews for the authenticated user
        * as a reviewer
        * as a coordinator
    * Adds a new tab to the navigational bar, which now requires icons in the navigational bar to be hidden on extremely small viewports
* Refactors the action menu that appears on the Submissions page into a new component, `SubmissionTableActions`, so that it can be reused on the Reviews page and throughout the application
* Adds a `SubmissionTable` component

**Bonus**

* Automatically loads submission title renaming activity to the Activity section on the Submission Details page without requiring the user to refresh the page
* Fixes the potential for pilcrow numbering to overlap with submission content on the Submission Review page

Closes #1754 