### PR TITLE
feat: Improve seeded submissions

### DIFF
--- a/backend/app/Listeners/NotifyUsersAboutUpdatedSubmissionStatus.php
+++ b/backend/app/Listeners/NotifyUsersAboutUpdatedSubmissionStatus.php
@@ -188,7 +188,7 @@ class NotifyUsersAboutUpdatedSubmissionStatus
     public function underReview($default)
     {
         $default['subject'] = 'Submission Under Review';
-        $default['body'] = $default['submission']['title'] . ' has been opened for review.' .
+        $default['body'] = $default['submission']['title'] . ' has been opened for review. ' .
                             'It is currently awaiting review from the assigned reviewers.';
         $default['type'] = 'submission.under_review';
 

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -21,15 +21,67 @@ class SubmissionSeeder extends Seeder
     {
         $this->callOnce(PublicationSeeder::class);
         $this->callOnce(UserSeeder::class);
+
         $this->createSubmission(100, 'Pilcrow Test Submission 1')
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1]);
-        $this->createSubmission(101, 'Pilcrow Test Submission 2');
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1]);
+
+        $this->createSubmission(101, 'Pilcrow Test Submission 2')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1]);
+
         $this->createSubmission(102, 'Pilcrow Test Submission 3')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
             ->update(['status' => Submission::REJECTED, 'updated_by' => 1]);
+
         $this->createSubmission(103, 'Pilcrow Test Submission 4')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
             ->update(['status' => Submission::RESUBMISSION_REQUESTED, 'updated_by' => 1]);
-        $this->createSubmission(104, 'Pilcrow Test Submission 5')
-            ->update(['status' => Submission::DRAFT, 'updated_by' => 1]);
+
+        $this->createSubmission(104, 'Pilcrow Test Submission 5');
+
+        $this->createSubmission(105, 'Pilcrow Test Submission 6')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::ACCEPTED_AS_FINAL, 'updated_by' => 1]);
+
+        $this->createSubmission(106, 'Pilcrow Test Submission 7')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::EXPIRED, 'updated_by' => 1]);
+
+        $this->createSubmission(107, 'Pilcrow Test Submission 8')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_DECISION, 'updated_by' => 1]);
+
+        $this->createSubmission(108, 'Pilcrow Test Submission 9')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_DECISION, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1]);
+
+        $this->createSubmission(109, 'Pilcrow Test Submission 10')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::ACCEPTED_AS_FINAL, 'updated_by' => 1])
+            ->update(['status' => Submission::ARCHIVED, 'updated_by' => 1]);
+
+        $this->createSubmission(110, 'Pilcrow Test Submission 11')
+            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
+            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
+            ->update(['status' => Submission::REJECTED, 'updated_by' => 1])
+            ->update(['status' => Submission::DELETED, 'updated_by' => 1]);
     }
 
     /**
@@ -48,7 +100,7 @@ class SubmissionSeeder extends Seeder
             'publication_id' => 1,
             'created_by' => 1,
             'updated_by' => 1,
-            'status' => Submission::INITIALLY_SUBMITTED,
+            'status' => Submission::DRAFT,
             ...$data,
         ];
 

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -23,65 +23,36 @@ class SubmissionSeeder extends Seeder
         $this->callOnce(UserSeeder::class);
 
         $this->createSubmission(100, 'Pilcrow Test Submission 1')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1]);
+            ->update(['updated_by' => 1, 'status' => Submission::UNDER_REVIEW]);
 
         $this->createSubmission(101, 'Pilcrow Test Submission 2')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1]);
+            ->update(['updated_by' => 6, 'status' => Submission::INITIALLY_SUBMITTED]);
 
         $this->createSubmission(102, 'Pilcrow Test Submission 3')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::REJECTED, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::REJECTED]);
 
         $this->createSubmission(103, 'Pilcrow Test Submission 4')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::RESUBMISSION_REQUESTED, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::RESUBMISSION_REQUESTED]);
 
-        $this->createSubmission(104, 'Pilcrow Test Submission 5');
+        $this->createSubmission(104, 'Pilcrow Test Submission 5'); // DRAFT
 
         $this->createSubmission(105, 'Pilcrow Test Submission 6')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::ACCEPTED_AS_FINAL, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::ACCEPTED_AS_FINAL]);
 
         $this->createSubmission(106, 'Pilcrow Test Submission 7')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::EXPIRED, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::EXPIRED]);
 
         $this->createSubmission(107, 'Pilcrow Test Submission 8')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_DECISION, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::AWAITING_DECISION]);
 
         $this->createSubmission(108, 'Pilcrow Test Submission 9')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_DECISION, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1]);
+            ->update(['updated_by' => 3, 'status' => Submission::AWAITING_REVIEW]);
 
         $this->createSubmission(109, 'Pilcrow Test Submission 10')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::ACCEPTED_AS_FINAL, 'updated_by' => 1])
-            ->update(['status' => Submission::ARCHIVED, 'updated_by' => 1]);
+            ->update(['updated_by' => 1, 'status' => Submission::ARCHIVED]);
 
         $this->createSubmission(110, 'Pilcrow Test Submission 11')
-            ->update(['status' => Submission::INITIALLY_SUBMITTED, 'updated_by' => 1])
-            ->update(['status' => Submission::AWAITING_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::UNDER_REVIEW, 'updated_by' => 1])
-            ->update(['status' => Submission::REJECTED, 'updated_by' => 1])
-            ->update(['status' => Submission::DELETED, 'updated_by' => 1]);
+            ->update(['updated_by' => 1, 'status' => Submission::DELETED]);
     }
 
     /**
@@ -98,8 +69,8 @@ class SubmissionSeeder extends Seeder
             'id' => $id,
             'title' => $title,
             'publication_id' => 1,
-            'created_by' => 1,
-            'updated_by' => 1,
+            'created_by' => 6,
+            'updated_by' => 6,
             'status' => Submission::DRAFT,
             ...$data,
         ];

--- a/client/src/pages/Publication/Setup/BasicPage.jest.spec.js
+++ b/client/src/pages/Publication/Setup/BasicPage.jest.spec.js
@@ -40,6 +40,7 @@ describe("BasicPage", () => {
           id: "1",
           name: "Test Name",
           is_publicly_available: false,
+          is_accepting_submissions: true,
         },
       },
     })

--- a/client/src/pages/Publication/Setup/BasicPage.jest.spec.js
+++ b/client/src/pages/Publication/Setup/BasicPage.jest.spec.js
@@ -39,8 +39,8 @@ describe("BasicPage", () => {
         publication: {
           id: "1",
           name: "Test Name",
-          is_publicly_available: false,
           is_accepting_submissions: true,
+          is_publicly_available: false,
         },
       },
     })
@@ -64,6 +64,7 @@ describe("BasicPage", () => {
     const newData = {
       name: "new name",
       is_publicly_visible: true,
+      is_accepting_submissions: true,
     }
 
     mutateHandler.mockResolvedValue({

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -64,7 +64,7 @@
         </q-form>
       </section>
       <section class="col-md-7 col-sm-6 col-xs-12">
-        <h3>All Submissions</h3>
+        <h3 data-cy="all_submissions_title">All Submissions</h3>
         <q-list
           v-if="submissions.length != 0"
           bordered

--- a/client/test/cypress/integration/notificationpopup.cy.js
+++ b/client/test/cypress/integration/notificationpopup.cy.js
@@ -16,7 +16,7 @@ describe("Notification Popup", () => {
   it("allows multiple notifications to be marked as read", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@pilcrow.dev" })
-    cy.visit("/submission/review/100")
+    cy.visit("/submission/review/108")
 
     cy.interceptGQLOperation("MarkAllNotificationsRead")
     cy.interceptGQLOperation("UpdateSubmissionStatus")

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -216,7 +216,7 @@ describe("Submissions Review", () => {
   it("should allow an application administrator to open a review, close a review, and that final decision options are visible", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@pilcrow.dev" })
-    cy.visit("submission/review/100")
+    cy.visit("submission/review/108")
     cy.dataCy("submission_status").contains("Awaiting Review")
     cy.dataCy("open_for_review").click()
     cy.dataCy("dirtyYesChangeStatus").click()

--- a/client/test/cypress/integration/submissions.cy.js
+++ b/client/test/cypress/integration/submissions.cy.js
@@ -192,7 +192,7 @@ describe("Submissions Page", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@pilcrow.dev" })
     cy.visit("submissions")
-    cy.dataCy("submission_actions").eq(4).should('not.exist')
+    cy.dataCy("submissions_list").should('not.include.text', 'Pilcrow Test Submission 5')
   })
 
   it("should allow an application administrator to open and close a review", () => {
@@ -202,7 +202,7 @@ describe("Submissions Page", () => {
 
     cy.interceptGQLOperation('UpdateSubmissionStatus')
 
-    cy.dataCy("submission_actions").first().click()
+    cy.dataCy("submission_actions").eq(7).click()
     cy.dataCy("change_status").click()
     cy.dataCy("open_review").click()
 
@@ -211,6 +211,9 @@ describe("Submissions Page", () => {
     cy.dataCy("change_status_notify")
       .should("be.visible")
       .should("have.class", "bg-positive")
+    cy.dataCy("all_submissions_title").click()
+    cy.dataCy("submission_actions").eq(7).click()
+    cy.dataCy("change_status").click()
     cy.dataCy("accept_as_final")
     cy.dataCy("close_review").click()
 


### PR DESCRIPTION
This pull request:

* Adds seeded submissions with the following states:
    - `Accepted as Final`
    - `Expired`
    - `Awaiting Decision`
    - `Awaiting Review`
    - `Archived`
    - `Deleted`
* Changes the status of the first seeded submission from `Awaiting Review` to `Under Review` to respect the existing review comments associated with this submission
* Changes the `updated_by` fields for status updates from the application admin (`applicationAdminUser`) to users that are more appropriate:
    - The submitter (`regularUser`)
        - changes the status for "Pilcrow Test Submission 2" `Initially Submitted`
    - The review coordinator (`reviewCoordinator`)
        - changes the status for "Pilcrow Test Submission 3" `Rejected` 
        - changes the status for "Pilcrow Test Submission 4" `Resubmission Requested` 
        - changes the status for "Pilcrow Test Submission 6" `Accepted as Final` 
        - changes the status for "Pilcrow Test Submission 7" `Expired` 
        - changes the status for "Pilcrow Test Submission 8" `Awaiting Decision` 
        - changes the status for "Pilcrow Test Submission 9" `Awaiting Review` 
* Changes the default `created_by` field for submissions to the submitter (`regularUser`)

**Bonus**
* Adds a missing space character to the email notification for submissions opened for review
* Adds missing properties to tests in `BasicPage.jest.spec.js` to avoid console errors

Closes #1767 