### PR TITLE
feat: Implement redesign of the Submissions page

### DIFF
--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -1,7 +1,6 @@
 extend type Submission {
     inline_comments: [InlineComment!]! @hasMany(relation: "inlineComments")
     overall_comments: [OverallComment!]! @hasMany(relation: "overallComments")
-    comments: [CommentUnion!]!
 }
 
 """
@@ -125,7 +124,3 @@ interface Comment {
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
 }
-"""
-A union of overall and inline comments
-"""
-union CommentUnion = InlineComment | OverallComment

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -1,6 +1,7 @@
 extend type Submission {
     inline_comments: [InlineComment!]! @hasMany(relation: "inlineComments")
     overall_comments: [OverallComment!]! @hasMany(relation: "overallComments")
+    comments: [CommentUnion!]!
 }
 
 """
@@ -124,3 +125,7 @@ interface Comment {
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
 }
+"""
+A union of overall and inline comments
+"""
+union CommentUnion = InlineComment | OverallComment

--- a/client/src/components/SubmissionTable.vue
+++ b/client/src/components/SubmissionTable.vue
@@ -60,7 +60,7 @@
           <q-card-section>
             {{ p.row.id }}
           </q-card-section>
-          <q-card-section class="full-width">
+          <q-card-section class="full-width" data-cy="submission_link_mobile">
             <div class="row justify-between">
               <router-link
                 :to="{
@@ -95,7 +95,7 @@
       </q-card>
     </template>
     <template #body-cell-title="p">
-      <q-td :props="p">
+      <q-td :props="p" data-cy="submission_link_desktop">
         <router-link
           :to="{
             name: 'submission_review',

--- a/client/src/components/atoms/CommentPreview.vue
+++ b/client/src/components/atoms/CommentPreview.vue
@@ -2,24 +2,28 @@
   <div data-cy="previewComment">
     <q-card
       square
-      class="bg-grey-1 shadow-2 q-mb-md comment"
+      class="bg-grey-1 shadow-2 q-mb-md comment full-height"
       :aria-label="
         $t('submissions.comment.ariaLabel', {
           display_label: comment.created_by.display_label,
         })
       "
     >
-    <q-card-section>
-      {{ comment.submission_title }}
-    </q-card-section>
+      <q-card-section>
+        {{ comment.submission_title }}
+      </q-card-section>
       <comment-preview-header
         :comment="comment"
         bg-color="#C9E5F8"
         class="comment-header"
       />
       <q-card-section>
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <div v-html="comment.content" />
+        <!-- eslint-disable vue/no-v-html -->
+        <div
+          style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical;"
+          v-html="comment.content"
+        />
+        <!-- eslint-enable vue/no-v-html -->
       </q-card-section>
 
       <q-card-actions align="right" class="q-pa-md">
@@ -34,7 +38,6 @@
           <span>View Comment</span>
         </q-btn>
       </q-card-actions>
-
     </q-card>
   </div>
 </template>

--- a/client/src/components/atoms/CommentPreview.vue
+++ b/client/src/components/atoms/CommentPreview.vue
@@ -2,31 +2,37 @@
   <div data-cy="previewComment">
     <q-card
       square
-      class="bg-grey-1 shadow-2 q-mb-md comment full-height"
+      class="bg-grey-1 shadow-2 q-mb-md comment full-height flex content-between"
       :aria-label="
-        $t('submissions.comment.ariaLabel', {
+        $t('submissions.comment_preview.ariaLabel', {
           display_label: comment.created_by.display_label,
         })
       "
     >
-      <q-card-section>
-        {{ comment.submission_title }}
-      </q-card-section>
-      <comment-preview-header
-        :comment="comment"
-        bg-color="#C9E5F8"
-        class="comment-header"
-      />
-      <q-card-section>
-        <!-- eslint-disable vue/no-v-html -->
-        <div
-          style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical;"
-          v-html="comment.content"
+      <div>
+        <q-card-section>
+          {{ comment.submission_title }}
+        </q-card-section>
+        <comment-preview-header
+          :comment="comment"
+          bg-color="#C9E5F8"
+          class="comment-header full-width"
         />
-        <!-- eslint-enable vue/no-v-html -->
-      </q-card-section>
-
-      <q-card-actions align="right" class="q-pa-md">
+        <q-card-section>
+          <!-- eslint-disable vue/no-v-html -->
+          <div
+            style="
+              overflow: hidden;
+              display: -webkit-box;
+              -webkit-line-clamp: 4;
+              -webkit-box-orient: vertical;
+            "
+            v-html="comment.content"
+          />
+          <!-- eslint-enable vue/no-v-html -->
+        </q-card-section>
+      </div>
+      <q-card-actions align="right" class="q-pa-md full-width self-end">
         <q-btn
           aria-label="View Comment"
           data-cy="viewCommentButton"

--- a/client/src/components/atoms/CommentPreview.vue
+++ b/client/src/components/atoms/CommentPreview.vue
@@ -20,16 +20,22 @@
         />
         <q-card-section>
           <!-- eslint-disable vue/no-v-html -->
-          <div
-            style="
-              overflow: hidden;
-              display: -webkit-box;
-              -webkit-line-clamp: 4;
-              -webkit-box-orient: vertical;
-            "
-            v-html="comment.content"
-          />
+          <div class="comment-preview" v-html="comment.content" />
           <!-- eslint-enable vue/no-v-html -->
+        </q-card-section>
+        <q-card-section
+          v-if="comment.style_criteria?.length"
+          class="q-mx-sm q-mb-sm q-pa-none"
+        >
+          <q-chip
+            v-for="criteria in comment.style_criteria"
+            :key="criteria.id"
+            size="16px"
+            :icon="criteria.icon"
+            data-cy="styleCriteria"
+          >
+            {{ criteria.name }}
+          </q-chip>
         </q-card-section>
       </div>
       <q-card-actions align="right" class="q-pa-md full-width self-end">
@@ -62,3 +68,12 @@ function viewComment() {
   console.log(`View Comment`)
 }
 </script>
+
+<style scoped>
+.comment-preview {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
+</style>

--- a/client/src/components/atoms/CommentPreview.vue
+++ b/client/src/components/atoms/CommentPreview.vue
@@ -5,12 +5,14 @@
       class="bg-grey-1 shadow-2 q-mb-md comment"
       :aria-label="
         $t('submissions.comment.ariaLabel', {
-          username: comment.created_by.username,
-          replies: comment.replies.length,
+          display_label: comment.created_by.display_label,
         })
       "
     >
-      <comment-header
+    <q-card-section>
+      {{ comment.submission_title }}
+    </q-card-section>
+      <comment-preview-header
         :comment="comment"
         bg-color="#C9E5F8"
         class="comment-header"
@@ -38,7 +40,7 @@
 </template>
 
 <script setup>
-import CommentHeader from "./CommentHeader.vue"
+import CommentPreviewHeader from "./CommentPreviewHeader.vue"
 
 defineProps({
   comment: {

--- a/client/src/components/atoms/CommentPreview.vue
+++ b/client/src/components/atoms/CommentPreview.vue
@@ -1,0 +1,53 @@
+<template>
+  <div data-cy="previewComment">
+    <q-card
+      square
+      class="bg-grey-1 shadow-2 q-mb-md comment"
+      :aria-label="
+        $t('submissions.comment.ariaLabel', {
+          username: comment.created_by.username,
+          replies: comment.replies.length,
+        })
+      "
+    >
+      <comment-header
+        :comment="comment"
+        bg-color="#C9E5F8"
+        class="comment-header"
+      />
+      <q-card-section>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div v-html="comment.content" />
+      </q-card-section>
+
+      <q-card-actions align="right" class="q-pa-md">
+        <q-btn
+          aria-label="View Comment"
+          data-cy="viewCommentButton"
+          bordered
+          color="secondary"
+          text-color="white"
+          @click="viewComment"
+        >
+          <span>View Comment</span>
+        </q-btn>
+      </q-card-actions>
+
+    </q-card>
+  </div>
+</template>
+
+<script setup>
+import CommentHeader from "./CommentHeader.vue"
+
+defineProps({
+  comment: {
+    type: Object,
+    required: true,
+  },
+})
+
+function viewComment() {
+  console.log(`View Comment`)
+}
+</script>

--- a/client/src/components/atoms/CommentPreviewHeader.vue
+++ b/client/src/components/atoms/CommentPreviewHeader.vue
@@ -1,15 +1,15 @@
 <template>
   <q-card-section class="q-py-xs" :style="style">
     <div class="row no-wrap justify-between">
-      <div class="row items-center">
+      <div class="row items-center no-wrap col-grow">
         <avatar-image :user="comment.created_by" round size="30px" />
-        <div class="text-h4 q-pl-sm">{{ comment.created_by.display_label }}</div>
+        <div class="text-h4 q-pl-sm ellipsis">{{ comment.created_by.display_label }}</div>
       </div>
       <div class="row items-center">
         <div
           v-if="comment.updated_at != comment.created_at"
           data-cy="timestampUpdated"
-          class="text-caption"
+          class="text-caption text-no-wrap"
           :aria-label="
             $t('submissions.comment.dateLabelUpdated', {
               date: relativeUpdatedTime,
@@ -27,7 +27,7 @@
         <div
           v-else
           data-cy="timestampCreated"
-          class="text-caption"
+          class="text-caption text-no-wrap"
           :aria-label="
             $t('submissions.comment.dateLabel', { date: relativeCreatedTime })
           "

--- a/client/src/components/atoms/CommentPreviewHeader.vue
+++ b/client/src/components/atoms/CommentPreviewHeader.vue
@@ -1,0 +1,92 @@
+<template>
+  <q-card-section class="q-py-xs" :style="style">
+    <div class="row no-wrap justify-between">
+      <div class="row items-center">
+        <avatar-image :user="comment.created_by" round size="30px" />
+        <div class="text-h4 q-pl-sm">{{ comment.created_by.display_label }}</div>
+      </div>
+      <div class="row items-center">
+        <div
+          v-if="comment.updated_at != comment.created_at"
+          data-cy="timestampUpdated"
+          class="text-caption"
+          :aria-label="
+            $t('submissions.comment.dateLabelUpdated', {
+              date: relativeUpdatedTime,
+            })
+          "
+        >
+          <q-tooltip
+            >{{ createdDate.toFormat("LLL dd yyyy hh:mm a") }} <br />
+            {{ $t("submissions.comment.updatedLabel") }}
+            {{ updatedDate.toFormat("LLL dd yyyy hh:mm a") }}
+          </q-tooltip>
+          {{ $t("submissions.comment.updatedLabel") }}
+          {{ relativeUpdatedTime }}
+        </div>
+        <div
+          v-else
+          data-cy="timestampCreated"
+          class="text-caption"
+          :aria-label="
+            $t('submissions.comment.dateLabel', { date: relativeCreatedTime })
+          "
+        >
+          <q-tooltip>
+            {{ createdDate.toFormat("LLL dd yyyy hh:mm a") }}
+          </q-tooltip>
+          {{ relativeCreatedTime }}
+        </div>
+      </div>
+    </div>
+  </q-card-section>
+</template>
+
+<script setup>
+import AvatarImage from "./AvatarImage.vue"
+import { useTimeAgo } from "src/use/timeAgo"
+import { DateTime } from "luxon"
+import { computed } from "vue"
+
+const timeAgo = useTimeAgo()
+const props = defineProps({
+  comment: {
+    type: Object,
+    required: true,
+  },
+  bgColor: {
+    type: String,
+    required: false,
+    default: null,
+  },
+})
+const style = computed(() => {
+  const style = {}
+  if (props.bgColor) {
+    style.backgroundColor = props.bgColor
+  }
+
+  return style
+})
+const createdDate = computed(() => {
+  return DateTime.fromISO(props.comment.created_at)
+})
+
+const relativeCreatedTime = computed(() => {
+  return createdDate.value
+    ? timeAgo.format(createdDate.value.toJSDate(), "long")
+    : ""
+})
+
+const updatedDate = computed(() => {
+  return props.comment?.updated_at
+    ? DateTime.fromISO(props.comment.updated_at)
+    : undefined
+})
+
+const relativeUpdatedTime = computed(() => {
+  return updatedDate.value
+    ? timeAgo.format(updatedDate.value.toJSDate(), "long")
+    : ""
+})
+</script>

--- a/client/src/components/atoms/CommentPreviewHeader.vue
+++ b/client/src/components/atoms/CommentPreviewHeader.vue
@@ -1,14 +1,14 @@
 <template>
   <q-card-section class="q-py-xs" :style="style">
-    <div class="row no-wrap items-center">
-      <div class="row no-wrap items-center q-pr-sm" style="min-width: 0">
-        <avatar-image
+    <div class="row items-center">
+      <avatar-image
           :user="comment.created_by"
           round
           size="30px"
           class="q-mr-sm"
         />
-        <div class="text-h4 ellipsis">
+      <div class="row items-center q-pr-sm" style="flex: 1; min-width: 0">
+        <div class="text-h4 ellipsis" :title="comment.created_by.display_label">
           {{ comment.created_by.display_label }}
         </div>
       </div>

--- a/client/src/components/atoms/CommentPreviewHeader.vue
+++ b/client/src/components/atoms/CommentPreviewHeader.vue
@@ -1,42 +1,47 @@
 <template>
   <q-card-section class="q-py-xs" :style="style">
-    <div class="row no-wrap justify-between">
-      <div class="row items-center no-wrap col-grow">
-        <avatar-image :user="comment.created_by" round size="30px" />
-        <div class="text-h4 q-pl-sm ellipsis">{{ comment.created_by.display_label }}</div>
+    <div class="row no-wrap items-center">
+      <div class="row no-wrap items-center q-pr-sm" style="min-width: 0">
+        <avatar-image
+          :user="comment.created_by"
+          round
+          size="30px"
+          class="q-mr-sm"
+        />
+        <div class="text-h4 ellipsis">
+          {{ comment.created_by.display_label }}
+        </div>
       </div>
-      <div class="row items-center">
-        <div
-          v-if="comment.updated_at != comment.created_at"
-          data-cy="timestampUpdated"
-          class="text-caption text-no-wrap"
-          :aria-label="
-            $t('submissions.comment.dateLabelUpdated', {
-              date: relativeUpdatedTime,
-            })
-          "
-        >
-          <q-tooltip
-            >{{ createdDate.toFormat("LLL dd yyyy hh:mm a") }} <br />
-            {{ $t("submissions.comment.updatedLabel") }}
-            {{ updatedDate.toFormat("LLL dd yyyy hh:mm a") }}
-          </q-tooltip>
+      <div
+        v-if="comment.updated_at != comment.created_at"
+        data-cy="timestampUpdated"
+        class="text-caption"
+        :aria-label="
+          $t('submissions.comment.dateLabelUpdated', {
+            date: relativeUpdatedTime,
+          })
+        "
+      >
+        <q-tooltip
+          >{{ createdDate.toFormat("LLL dd yyyy hh:mm a") }} <br />
           {{ $t("submissions.comment.updatedLabel") }}
-          {{ relativeUpdatedTime }}
-        </div>
-        <div
-          v-else
-          data-cy="timestampCreated"
-          class="text-caption text-no-wrap"
-          :aria-label="
-            $t('submissions.comment.dateLabel', { date: relativeCreatedTime })
-          "
-        >
-          <q-tooltip>
-            {{ createdDate.toFormat("LLL dd yyyy hh:mm a") }}
-          </q-tooltip>
-          {{ relativeCreatedTime }}
-        </div>
+          {{ updatedDate.toFormat("LLL dd yyyy hh:mm a") }}
+        </q-tooltip>
+        {{ $t("submissions.comment.updatedLabel") }}
+        {{ relativeUpdatedTime }}
+      </div>
+      <div
+        v-else
+        data-cy="timestampCreated"
+        class="text-caption text-no-wrap"
+        :aria-label="
+          $t('submissions.comment.dateLabel', { date: relativeCreatedTime })
+        "
+      >
+        <q-tooltip>
+          {{ createdDate.toFormat("LLL dd yyyy hh:mm a") }}
+        </q-tooltip>
+        {{ relativeCreatedTime }}
       </div>
     </div>
   </q-card-section>

--- a/client/src/graphql/fragments.js
+++ b/client/src/graphql/fragments.js
@@ -40,6 +40,7 @@ export const _CURRENT_USER_FIELDS = gql`
 export const _RELATED_USER_FIELDS = gql`
   fragment relatedUserFields on User {
     id
+    display_label
     username
     name
     email

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -92,6 +92,11 @@ export const CURRENT_USER_SUBMISSIONS = gql`
           }
           created_at
           updated_at
+          style_criteria {
+            id
+            name
+            icon
+          }
         }
         overall_comments {
           id

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -77,6 +77,38 @@ export const CURRENT_USER_SUBMISSIONS = gql`
         status
         my_role
         effective_role
+        inline_comments {
+          id
+          content
+          created_by {
+            id
+            display_label
+            email
+          }
+          updated_by{
+            id
+            display_label
+            email
+          }
+          created_at
+          updated_at
+        }
+        overall_comments {
+          id
+          content
+          created_by{
+            id
+            display_label
+            email
+          }
+          updated_by{
+            id
+            display_label
+            email
+          }
+          created_at
+          updated_at
+        }
         publication {
           id
           name

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -348,6 +348,12 @@
         "title": "Submissions",
         "byline": "{type_name} you have submitted for review"
       }
+    },
+    "submissions": {
+      "submitter": {
+        "title": "All Submissions",
+        "byline": "{type_name} you have submitted for review"
+      }
     }
   },
   "publication": {
@@ -633,6 +639,8 @@
     }
   },
   "submissions": {
+    "heading": "Submissions",
+    "none": "No Submissions Created",
     "details_heading": "Submission Details",
     "action": {
       "toggle_label": "Toggle Submission Actions",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -711,6 +711,9 @@
       }
     },
     "inline_comments_heading": "Inline Comments",
+    "comment_preview": {
+      "ariaLabel": "Comment Preview. Author {display_label}."
+    },
     "comment": {
       "ariaLabel": "Comment. Author {username}. {replies} replies.",
       "dateLabel": "Created {date}",

--- a/client/src/pages/SubmissionsPage.vitest.spec.js
+++ b/client/src/pages/SubmissionsPage.vitest.spec.js
@@ -1,24 +1,27 @@
 import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-vitest"
 import { mount, flushPromises } from "@vue/test-utils"
 import { installApolloClient } from "test/vitest/utils"
-import { GET_PUBLICATIONS, GET_SUBMISSIONS } from "src/graphql/queries"
+import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
+import { useCurrentUser } from "src/use/user"
+import { describe, expect, test, vi, afterEach } from "vitest"
+import { ref } from "vue"
 import SubmissionsPage from "./SubmissionsPage.vue"
-
-import { describe, expect, test, vi } from "vitest"
-
-vi.mock("quasar", () => ({
-  ...vi.requireActual("quasar"),
-  useQuasar: () => ({
-    notify: vi.fn(),
-  }),
+vi.mock("src/use/user", () => ({
+  useCurrentUser: vi.fn(),
 }))
 
 installQuasarPlugin()
 const mockClient = installApolloClient()
 
-describe("submissions page mount", () => {
+describe("Submissions Page", () => {
+  const CurrentUserSubmissions = vi.fn()
+  mockClient.setRequestHandler(CURRENT_USER_SUBMISSIONS, CurrentUserSubmissions)
 
-  const makeWrapper = async () => {
+  afterEach(() => {
+    CurrentUserSubmissions.mockClear()
+  })
+
+  const wrapperFactory = async () => {
     const wrapper = mount(SubmissionsPage, {
       global: {
         stubs: ["router-link"],
@@ -28,48 +31,34 @@ describe("submissions page mount", () => {
     return wrapper
   }
 
-  const getSubsHandler = vi.fn()
-  mockClient.setRequestHandler(GET_SUBMISSIONS, getSubsHandler)
-  const getPubsHandler = vi.fn()
-  mockClient.setRequestHandler(GET_PUBLICATIONS, getPubsHandler)
-
-  const mockPublications = () => {
-    getPubsHandler.mockResolvedValue({
-      data: {
-        publications: {
-          paginatorInfo: {
-            __typename: "PaginatorInfo",
-            count: 1,
-            currentPage: 1,
-            lastPage: 1,
-            perPage: 10,
-          },
-          data: [{ id: 1, name: "Jest Publication", home_page_content: "" }],
-        },
-      },
+  test("able to mount", async () => {
+    useCurrentUser.mockReturnValue({
+      currentUser: ref({ id: 1 }),
     })
-  }
+    const wrapper = await wrapperFactory()
+    expect(wrapper).toBeTruthy()
+  })
 
-  test("all existing submissions appear within the list", async () => {
-    getSubsHandler.mockResolvedValue({
+  test("all expected submissions appear", async () => {
+    useCurrentUser.mockReturnValue({
+      currentUser: ref({ id: 1 }),
+    })
+
+    CurrentUserSubmissions.mockResolvedValue({
       data: {
-        submissions: {
-          paginatorInfo: {
-            __typename: "PaginatorInfo",
-            count: 5,
-            currentPage: 1,
-            lastPage: 1,
-            perPage: 10,
-          },
-          data: [
+        currentUser: {
+          id: 1000,
+          roles: [],
+          submissions: [
             {
               id: "1",
               title: "Jest Submission 1",
               status: "INITIALLY_SUBMITTED",
               my_role: "submitter",
               effective_role: "submitter",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
             },
             {
               id: "2",
@@ -77,8 +66,9 @@ describe("submissions page mount", () => {
               status: "RESUBMISSION_REQUESTED",
               my_role: "reviewer",
               effective_role: "reviewer",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
             },
             {
               id: "3",
@@ -86,8 +76,9 @@ describe("submissions page mount", () => {
               status: "AWAITING_REVIEW",
               my_role: "review_coordinator",
               effective_role: "review_coordinator",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
             },
             {
               id: "4",
@@ -95,8 +86,9 @@ describe("submissions page mount", () => {
               status: "REJECTED",
               my_role: "",
               effective_role: "review_coordinator",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
             },
             {
               id: "5",
@@ -104,17 +96,217 @@ describe("submissions page mount", () => {
               status: "INITIALLY_SUBMITTED",
               my_role: "",
               effective_role: "",
-              publication: { name: "Jest Publication" },
-              files: [],
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
+            },
+            {
+              id: "6",
+              title: "Jest Submission 6",
+              status: "INITIALLY_SUBMITTED",
+              my_role: "submitter",
+              effective_role: "submitter",
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [],
+              overall_comments: [],
             },
           ],
         },
       },
     })
-    mockPublications()
-    const wrapper = await makeWrapper()
-    expect(wrapper.findAllComponents({ name: "q-item" })).toHaveLength(5)
+    const wrapper = await wrapperFactory()
+    expect(wrapper.findAllComponents({ name: "submission-table" }).length).toBe(
+      1
+    )
+    expect(wrapper.findAll('[data-cy="submission_link_desktop"]').length).toBe(
+      2
+    )
   })
 
-  //TODO: Test submission creation
+  test("comment previews appear within the latest comments section", async () => {
+    useCurrentUser.mockReturnValue({
+      currentUser: ref({ id: 1 }),
+    })
+    CurrentUserSubmissions.mockResolvedValue({
+      data: {
+        currentUser: {
+          id: 1000,
+          roles: [],
+          submissions: [
+            {
+              id: "1",
+              title: "Jest Submission 1",
+              status: "INITIALLY_SUBMITTED",
+              my_role: "submitter",
+              effective_role: "submitter",
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [
+                {
+                  id: "1",
+                  content: "Jest Inline Comment 1",
+                  style_criteria: [
+                    { id: 1, name: "Jest Style Criteria", icon: "home" },
+                    { id: 2, name: "Jest Style Criteria", icon: "search" },
+                  ],
+                  created_by: {
+                    id: "1",
+                    display_label: "Application Administrator",
+                    username: "applicationAdminUser",
+                    email: "applicationadministrator@pilcrow.dev",
+                  },
+                  created_at: "2023-03-24T02:01:00.000000Z",
+                  updated_by: {
+                    id: "1",
+                    display_label: "Application Administrator",
+                    username: "applicationAdminUser",
+                    email: "applicationadministrator@pilcrow.dev",
+                  },
+                  updated_at: "2023-03-24T02:01:00.000000Z",
+                },
+                {
+                  id: "2",
+                  content: "Jest Inline Comment 2",
+                  style_criteria: [
+                    { id: 6, name: "Jest Style Criteria", icon: "info" },
+                  ],
+                  created_by: {
+                    id: "3",
+                    display_label: "Publication Editor",
+                    username: "publicationEditor",
+                    email: "publicationEditor@pilcrow.dev",
+                  },
+                  created_at: "2023-03-25T05:27:07.000000Z",
+                  updated_by: {
+                    id: "3",
+                    display_label: "Publication Editor",
+                    username: "publicationEditor",
+                    email: "publicationEditor@pilcrow.dev",
+                  },
+                  updated_at: "2023-03-25T05:27:07.000000Z",
+                },
+              ],
+              overall_comments: [
+                {
+                  id: "1",
+                  content: "Jest Overall Comment 1",
+                  created_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  created_at: "2023-03-27T08:21:44.000000Z",
+                  updated_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  updated_at: "2023-03-27T08:21:44.000000Z",
+                },
+              ],
+            },
+            {
+              id: "2",
+              title: "Jest Submission 2",
+              status: "RESUBMISSION_REQUESTED",
+              my_role: "reviewer",
+              effective_role: "reviewer",
+              publication: { id: 1, name: "Jest Publication", my_role: "" },
+              inline_comments: [
+                {
+                  id: "3",
+                  content: "Jest Inline Comment 3",
+                  style_criteria: [
+                    { id: 12, name: "Jest Style Criteria", icon: "visibility" },
+                  ],
+                  created_by: {
+                    id: "3",
+                    display_label: "Publication Editor",
+                    username: "publicationEditor",
+                    email: "publicationEditor@pilcrow.dev",
+                  },
+                  created_at: "2023-04-08T02:01:03.000000Z",
+                  updated_by: {
+                    id: "3",
+                    display_label: "Publication Editor",
+                    username: "publicationEditor",
+                    email: "publicationEditor@pilcrow.dev",
+                  },
+                  updated_at: "2023-04-08T02:01:03.000000Z",
+                },
+                {
+                  id: "4",
+                  content: "Jest Inline Comment 4",
+                  style_criteria: [
+                    {
+                      id: 16,
+                      name: "Jest Style Criteria",
+                      icon: "description",
+                    },
+                  ],
+                  created_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  created_at: "2023-04-09T02:25:03.000000Z",
+                  updated_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  updated_at: "2023-04-09T02:25:03.000000Z",
+                },
+              ],
+              overall_comments: [
+                {
+                  id: "2",
+                  content: "Jest Overall Comment 2",
+                  created_by: {
+                    id: "1",
+                    display_label: "Application Administrator",
+                    username: "applicationAdminUser",
+                    email: "applicationadministrator@pilcrow.dev",
+                  },
+                  created_at: "2023-04-10T07:12:35.000000Z",
+                  updated_by: {
+                    id: "1",
+                    display_label: "Application Administrator",
+                    username: "applicationAdminUser",
+                    email: "applicationadministrator@pilcrow.dev",
+                  },
+                  updated_at: "2023-04-10T07:12:35.000000Z",
+                },
+                {
+                  id: "3",
+                  content: "Jest Overall Comment 3",
+                  created_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  created_at: "2023-04-07T05:25:03.000000Z",
+                  updated_by: {
+                    id: "5",
+                    display_label: "Reviewer for Submission",
+                    username: "reviewer",
+                    email: "reviewer@pilcrow.dev"
+                  },
+                  updated_at: "2023-04-08T05:25:03.000000Z",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    })
+    const wrapper = await wrapperFactory()
+    expect(wrapper.findAllComponents({ name: "comment-preview" }).length).toBe(
+      3
+    )
+  })
 })

--- a/client/src/pages/SubmissionsPage.vitest.spec.js
+++ b/client/src/pages/SubmissionsPage.vitest.spec.js
@@ -193,14 +193,14 @@ describe("Submissions Page", () => {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   created_at: "2023-03-27T08:21:44.000000Z",
                   updated_by: {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   updated_at: "2023-03-27T08:21:44.000000Z",
                 },
@@ -249,14 +249,14 @@ describe("Submissions Page", () => {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   created_at: "2023-04-09T02:25:03.000000Z",
                   updated_by: {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   updated_at: "2023-04-09T02:25:03.000000Z",
                 },
@@ -287,14 +287,14 @@ describe("Submissions Page", () => {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   created_at: "2023-04-07T05:25:03.000000Z",
                   updated_by: {
                     id: "5",
                     display_label: "Reviewer for Submission",
                     username: "reviewer",
-                    email: "reviewer@pilcrow.dev"
+                    email: "reviewer@pilcrow.dev",
                   },
                   updated_at: "2023-04-08T05:25:03.000000Z",
                 },

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -25,7 +25,7 @@
         <h3>Latest Comments</h3>
       </div>
       <div class="row q-col-gutter-lg">
-        <div v-for="comment in inline_comments" :key="comment.id" class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
+        <div v-for="comment in latest_comments" :key="comment.id" class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
           <comment-preview
             class="flex fit"
             :comment="comment"
@@ -54,12 +54,17 @@ const submitter_submissions = computed(() =>
     return submission.my_role == "submitter"
   })
 )
-const inline_comments = computed(() => {
+const latest_comments = computed(() => {
   const comments = submitter_submissions.value.map((submission) => {
-    return submission.inline_comments.map((comment) => ({
+    const inline = submission.inline_comments.map((comment) => ({
       ...comment,
       submission_title: submission.title,
-    }))
+    })).flat()
+    const overall = submission.overall_comments.map((comment) => ({
+      ...comment,
+      submission_title: submission.title,
+    })).flat()
+    return inline.concat(overall)
   })
   return comments
     .flat()

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -25,11 +25,12 @@
         <h3>Latest Comments</h3>
       </div>
       <div class="row q-col-gutter-lg">
-        <div v-for="comment in latest_comments" :key="comment.id" class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
-          <comment-preview
-            class="flex fit"
-            :comment="comment"
-          />
+        <div
+          v-for="comment in latest_comments"
+          :key="comment.id"
+          class="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+        >
+          <comment-preview class="flex fit" :comment="comment" />
         </div>
       </div>
     </section>
@@ -55,22 +56,23 @@ const submitter_submissions = computed(() =>
   })
 )
 const latest_comments = computed(() => {
-  const comments = submitter_submissions.value.map((submission) => {
-    const inline = submission.inline_comments.map((comment) => ({
-      ...comment,
-      submission_title: submission.title,
-    })).flat()
-    const overall = submission.overall_comments.map((comment) => ({
-      ...comment,
-      submission_title: submission.title,
-    })).flat()
+  let comments = submitter_submissions.value.map((submission) => {
+    const inline = submission.inline_comments
+      .map((comment) => ({
+        ...comment,
+        submission_title: submission.title,
+      }))
+      .flat()
+    const overall = submission.overall_comments
+      .map((comment) => ({
+        ...comment,
+        submission_title: submission.title,
+      }))
+      .flat()
     return inline.concat(overall)
   })
-  return comments
-    .flat()
-    .sort((a, b) => {
-      return a.updated_at - b.updated_at
-    })
-    .reverse()
+  return comments.flat().sort((a, b) => {
+    return new Date(b.updated_at) - new Date(a.updated_at)
+  })
 })
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -1,116 +1,22 @@
 <template>
   <article>
-    <h2 class="q-pl-lg">Submissions</h2>
+    <h2 class="q-pl-lg" data-cy="submissions_title">
+      {{ $t(`submissions.heading`) }}
+    </h2>
     <div class="row q-col-gutter-lg q-pa-lg">
-      <section
-        class="col-md-5 col-sm-6 col-xs-12"
-        data-cy="create_new_submission_form"
-      >
-        <h3>Create New Submission</h3>
-        <q-form @submit="createNewSubmission()">
-          <div class="q-gutter-md column q-pl-none q-pr-md">
-            <q-input
-              v-model="new_submission.title"
-              outlined
-              label="Enter Submission Title"
-              data-cy="new_submission_title_input"
-            />
-            <q-select
-              v-model="new_submission.publication_id"
-              outlined
-              :options="publications"
-              option-label="name"
-              option-value="id"
-              emit-value
-              map-options
-              label="For Publication"
-              popup-content-class="publication_options"
-              data-cy="new_submission_publication_input"
-            />
-            <q-file
-              v-model="new_submission.file_upload"
-              outlined
-              label="Upload File"
-              multiple
-              data-cy="new_submission_file_upload_input"
-            >
-              <template #prepend>
-                <q-icon
-                  color="accent"
-                  class="accent-dark-text"
-                  name="attach_file"
-                />
-              </template>
-            </q-file>
-          </div>
-          <q-banner
-            v-if="try_catch_error"
-            dense
-            rounded
-            background-color="negative"
-            class="form-error text-white text-center q-mt-xs"
-            data-cy="banner_form_error"
-          >
-            {{ $t(`submissions.create.failure`) }}
-          </q-banner>
-          <q-btn
-            :disabled="is_submitting"
-            class="accent text-white q-mt-lg"
-            type="submit"
-            data-cy="save_submission"
-          >
-            Save
-          </q-btn>
-        </q-form>
-      </section>
-      <section class="col-md-7 col-sm-6 col-xs-12">
-        <h3 data-cy="all_submissions_title">All Submissions</h3>
-        <q-list
-          v-if="submissions.length != 0"
-          bordered
-          separator
-          data-cy="submissions_list"
-        >
-          <q-item
-            v-for="submission in submissions"
-            :key="submission.id"
-            class="row justify-between"
-          >
-            <q-item-section>
-              <router-link
-                data-cy="submission_link"
-                :to="{
-                  name: 'submission_details',
-                  params: { id: submission.id },
-                }"
-              >
-                <q-item-label>{{ submission.title }}</q-item-label>
-              </router-link>
-              <q-item-label caption>
-                for {{ submission.publication.name }}
-
-                <!-- <ul v-if="submission.files.length > 0">
-                    <li v-for="file in submission.files" :key="file.id">
-                      <a :href="file.file_upload" download>
-                        {{ file.file_upload }}
-                      </a>
-                    </li>
-                  </ul> -->
-              </q-item-label>
-            </q-item-section>
-            <div class="q-gutter-sm submission-options">
-              <submission-table-actions :submission="submission" />
-            </div>
-          </q-item>
-        </q-list>
+      <section class="col-12">
         <div v-if="subsLoading" class="q-pa-lg">
           {{ $t("loading") }}
         </div>
-        <div
-          v-else-if="submissions.length == 0"
-          data-cy="no_submissions_message"
-        >
-          No Submissions Created
+
+        <div v-else-if="currentUser" class="col-12">
+          <submission-table
+            :table-data="submitter_submissions"
+            variation="submissions"
+            table-type="submissions"
+            role="submitter"
+            data-cy="submissions_table"
+          />
         </div>
       </section>
     </div>
@@ -118,114 +24,21 @@
 </template>
 
 <script setup>
-import { GET_PUBLICATIONS, GET_SUBMISSIONS } from "src/graphql/queries"
-import { CREATE_SUBMISSION } from "src/graphql/mutations"
-import { required, maxLength } from "@vuelidate/validators"
+import { CURRENT_USER_SUBMISSIONS } from "src/graphql/queries"
 import { useCurrentUser } from "src/use/user"
-import { useFeedbackMessages } from "src/use/guiElements"
-import { useI18n } from "vue-i18n"
-import { ref, reactive, computed } from "vue"
-import { useQuery, useMutation } from "@vue/apollo-composable"
-import useVuelidate from "@vuelidate/core"
-import SubmissionTableActions from "../components/SubmissionTableActions.vue"
+import { computed } from "vue"
+import { useQuery } from "@vue/apollo-composable"
+import SubmissionTable from "src/components/SubmissionTable.vue"
 
 const { currentUser } = useCurrentUser()
-
-function includeDraftSubmissions(submission) {
-  return (
-    (submission.my_role == "submitter" && submission.status == "DRAFT") ||
-    submission.status !== "DRAFT"
-  )
-}
-
-const is_submitting = ref(false)
-const try_catch_error = ref(false)
-const new_submission = reactive({
-  title: "",
-  publication_id: null,
-  submitter_user_id: null,
-  file_upload: [],
-})
-
-//TODO: Implement validation rules a little more DRYly
-const rules = {
-  title: { required, maxLength: maxLength(512) },
-  publication_id: { required },
-  submitter_user_id: { required },
-  file_upload: { required },
-}
-
-const newPubV$ = useVuelidate(rules, new_submission)
-
-const { result: subsResult, loading: subsLoading } = useQuery(GET_SUBMISSIONS)
-
+const { result, loading: subsLoading } = useQuery(CURRENT_USER_SUBMISSIONS)
 const submissions = computed(() => {
-  return (
-    subsResult.value?.submissions.data.filter((submission) =>
-      includeDraftSubmissions(submission)
-    ) ?? []
-  )
+  return result.value?.currentUser?.submissions ?? []
 })
+const submitter_submissions = computed(() =>
+  submissions.value.filter(function (submission) {
+    return submission.my_role == "submitter"
+  })
+)
 
-const { result: pubsResult } = useQuery(GET_PUBLICATIONS)
-const publications = computed(() => {
-  return pubsResult.value?.publications.data ?? []
-})
-const { t } = useI18n()
-const { newStatusMessage } = useFeedbackMessages({
-  attrs: {
-    "data-cy": "create_submission_notify",
-  },
-})
-
-function checkThatFormIsInvalid() {
-  let failureMessage = false
-  if (newPubV$.value.title.maxLength.$invalid) {
-    failureMessage = "submissions.create.title.max_length"
-  } else if (newPubV$.value.title.required.$invalid) {
-    failureMessage = "submissions.create.title.required"
-  } else if (newPubV$.value.publication_id.required.$invalid) {
-    failureMessage = "submissions.create.publication_id.required"
-  } else if (newPubV$.value.submitter_user_id.required.$invalid) {
-    failureMessage = "submissions.create.submitter_user_id.required"
-  } else if (newPubV$.value.file_upload.required.$invalid) {
-    failureMessage = "submissions.create.file_upload.required"
-  }
-
-  if (failureMessage !== false) {
-    newStatusMessage("failure", t(failureMessage))
-    return true
-  }
-  return false
-}
-
-const { mutate: createMutate } = useMutation(CREATE_SUBMISSION, {
-  context: {
-    hasUpload: true,
-  },
-  refetchQueries: ["GetSubmissions", "currentUserNotifications"],
-})
-
-async function createNewSubmission() {
-  is_submitting.value = true
-  try_catch_error.value = false
-  new_submission.submitter_user_id = currentUser.value.id
-  if (checkThatFormIsInvalid()) {
-    is_submitting.value = false
-    return false
-  }
-  try {
-    await createMutate({ ...new_submission })
-    newStatusMessage("success", t("submissions.create.success"))
-    resetForm()
-    is_submitting.value = false
-  } catch (error) {
-    try_catch_error.value = true
-    is_submitting.value = false
-  }
-
-  function resetForm() {
-    Object.assign(new_submission, { title: "", file_upload: [] })
-  }
-}
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -22,11 +22,14 @@
     </section>
     <section class="q-pa-lg">
       <div class="row">
-        <h3>Newest Comments</h3>
+        <h3>Latest Comments</h3>
       </div>
       <div class="row q-col-gutter-lg">
         <div v-for="comment in inline_comments" :key="comment.id" class="col-3">
-          <comment-preview :comment="comment" />
+          <comment-preview
+            class="flex full-height"
+            :comment="comment"
+          />
         </div>
       </div>
     </section>
@@ -53,14 +56,16 @@ const submitter_submissions = computed(() =>
 )
 const inline_comments = computed(() => {
   const comments = submitter_submissions.value.map((submission) => {
-    return submission.inline_comments.map(
-      (comment) => ({
-        ...comment, submission_title: submission.title
-      })
-    )
+    return submission.inline_comments.map((comment) => ({
+      ...comment,
+      submission_title: submission.title,
+    }))
   })
-  return comments.flat().sort((a, b) => {
-    return a.updated_at - b.updated_at
-  }).reverse()
+  return comments
+    .flat()
+    .sort((a, b) => {
+      return a.updated_at - b.updated_at
+    })
+    .reverse()
 })
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -3,8 +3,8 @@
     <h2 class="q-pl-lg" data-cy="submissions_title">
       {{ $t(`submissions.heading`) }}
     </h2>
-    <div class="row q-col-gutter-lg q-pa-lg">
-      <section class="col-12">
+    <section class="row q-col-gutter-lg q-pa-lg">
+      <div class="col-12">
         <div v-if="subsLoading" class="q-pa-lg">
           {{ $t("loading") }}
         </div>
@@ -18,8 +18,19 @@
             data-cy="submissions_table"
           />
         </div>
-      </section>
-    </div>
+      </div>
+    </section>
+    <section class="q-pa-lg">
+      <div class="row">
+        <h3>New Comments</h3>
+      </div>
+      <div class="row q-col-gutter-lg">
+        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
+        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
+        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
+        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
+      </div>
+    </section>
   </article>
 </template>
 
@@ -29,6 +40,7 @@ import { useCurrentUser } from "src/use/user"
 import { computed } from "vue"
 import { useQuery } from "@vue/apollo-composable"
 import SubmissionTable from "src/components/SubmissionTable.vue"
+import CommentPreview from "src/components/atoms/CommentPreview.vue"
 
 const { currentUser } = useCurrentUser()
 const { result, loading: subsLoading } = useQuery(CURRENT_USER_SUBMISSIONS)
@@ -40,5 +52,12 @@ const submitter_submissions = computed(() =>
     return submission.my_role == "submitter"
   })
 )
-
+const sampleComment = {
+  created_at: "2022-06-05T01:57:20Z",
+  created_by: {
+    username: "Hello",
+  },
+  replies: [],
+  content: "Lorem Ipsum",
+}
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -71,8 +71,11 @@ const latest_comments = computed(() => {
       .flat()
     return inline.concat(overall)
   })
-  return comments.flat().sort((a, b) => {
-    return new Date(b.updated_at) - new Date(a.updated_at)
-  })
+  return comments
+    .flat()
+    .sort((a, b) => {
+      return new Date(b.updated_at) - new Date(a.updated_at)
+    })
+    .slice(0, 4)
 })
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -22,13 +22,12 @@
     </section>
     <section class="q-pa-lg">
       <div class="row">
-        <h3>New Comments</h3>
+        <h3>Newest Comments</h3>
       </div>
       <div class="row q-col-gutter-lg">
-        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
-        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
-        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
-        <div class="col-3"><comment-preview :comment="sampleComment" /></div>
+        <div v-for="comment in inline_comments" :key="comment.id" class="col-3">
+          <comment-preview :comment="comment" />
+        </div>
       </div>
     </section>
   </article>
@@ -52,12 +51,16 @@ const submitter_submissions = computed(() =>
     return submission.my_role == "submitter"
   })
 )
-const sampleComment = {
-  created_at: "2022-06-05T01:57:20Z",
-  created_by: {
-    username: "Hello",
-  },
-  replies: [],
-  content: "Lorem Ipsum",
-}
+const inline_comments = computed(() => {
+  const comments = submitter_submissions.value.map((submission) => {
+    return submission.inline_comments.map(
+      (comment) => ({
+        ...comment, submission_title: submission.title
+      })
+    )
+  })
+  return comments.flat().sort((a, b) => {
+    return a.updated_at - b.updated_at
+  }).reverse()
+})
 </script>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -25,9 +25,9 @@
         <h3>Latest Comments</h3>
       </div>
       <div class="row q-col-gutter-lg">
-        <div v-for="comment in inline_comments" :key="comment.id" class="col-3">
+        <div v-for="comment in inline_comments" :key="comment.id" class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
           <comment-preview
-            class="flex full-height"
+            class="flex fit"
             :comment="comment"
           />
         </div>

--- a/client/test/cypress/integration/submissions.cy.js
+++ b/client/test/cypress/integration/submissions.cy.js
@@ -211,7 +211,7 @@ describe("Submissions Page", () => {
     cy.dataCy("change_status_notify")
       .should("be.visible")
       .should("have.class", "bg-positive")
-    cy.dataCy("all_submissions_title").click()
+    cy.dataCy("submissions_title").click()
     cy.dataCy("submission_actions").eq(7).click()
     cy.dataCy("change_status").click()
     cy.dataCy("accept_as_final")


### PR DESCRIPTION
This pull request updates the layout of the Submissions page so that it shows a submission table of the authenticated user's submissions as well as the latest inline and overall comments on those submissions.

Closes #1794 