### PR TITLE
chore: do not publish docker images on pull requests or rennovate action

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ${{ steps.context.outputs.context }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'renovate') }}
           build-args: |
             COMPOSER_NO_DEV=${{ steps.context.outputs.nodev }}
             VERSION=${{ steps.tagger.outputs.version }}


### PR DESCRIPTION
This PR adds a conditional to the publishing of container images to help prevent build errors on pull requests.