### PR TITLE
chore(lando): check for architecture when installing pandoc

### DIFF
--- a/.lando/install-pandoc.sh
+++ b/.lando/install-pandoc.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-
-wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb -O /tmp/pandoc.deb && \
+arch=$(uname -m)
+if [ "$arch" = "aarch64" ]; then #M1 Mac
+  echo Installing ARM64 version of Pandoc
+  build="arm64"
+else
+  echo Installing AMD64 version of Pandoc
+  build="amd64"
+fi
+wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-${build}.deb -O /tmp/pandoc.deb && \
 dpkg -i /tmp/pandoc.deb
 rm /tmp/pandoc.deb


### PR DESCRIPTION
Updates the pandoc installation script to install the correct architecture of pandoc on M1 Macs.