### PR TITLE
docs(style): fix Bare URL markdownlint violation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,7 +98,7 @@ To run linter/style checker:
 
 ## Reporting a Security Issue
 
-If you've found a security related issue in Pilcrow, please don't open an issue in github. Instead contact MESH Research at mesh@msu.edu.
+If you've found a security related issue in Pilcrow, please don't open an issue in GitHub. Instead contact MESH Research at <mesh@msu.edu>.
 
 ## Additional Resources
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at adamsb@msu.edu. All
+reported by contacting the project team at <mesh@msu.edu>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/client/src/apollo/apollo-router-guards.vitest.spec.js
+++ b/client/src/apollo/apollo-router-guards.vitest.spec.js
@@ -1,11 +1,11 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { beforeEachRequiresAuth, beforeEachRequiresRoles } from './apollo-router-guards'
-import { vi, describe, it, expect, afterEach } from 'vitest'
 
 const apolloMock = {
   query: vi.fn(),
 }
 
-describe("requiresAuth router hook", async () => {
+describe("requiresAuth router hook", () => {
   afterEach(() => {
     apolloMock.query.mockClear()
   })
@@ -72,7 +72,7 @@ describe("requiresAuth router hook", async () => {
   })
 })
 
-describe("requiresRoles router hook", async () => {
+describe("requiresRoles router hook", () => {
   afterEach(() => {
     apolloMock.query.mockClear()
   })

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -136,12 +136,12 @@ The users below are permanent on the test servers, and will not be deleted. Howe
 
 Name | Username | Login email | Login Password
 :---- | :---- | :---- | :----
-Application Administrator | applicationAdminUser | `applicationadministrator@pilcrow.dev` | adminPassword!@#
-Publication Administrator | publicationAdministrator | `publicationAdministrator@pilcrow.dev` | publicationadminPassword!@#
-Publication Editor | publicationEditor | `publicationEditor@pilcrow.dev` | editorPassword!@#
-Review Coordinator for Submission | reviewCoordinator | `reviewCoordinator@pilcrow.dev` | coordinatorPassword!@#
-Reviewer for Submission | reviewer | `reviewer@pilcrow.dev` | reviewerPassword!@#
-Regular User | regularUser | `regularuser@pilcrow.dev` | regularPassword!@#
+Application Administrator | applicationAdminUser | `applicationadministrator@pilcrow.dev` | `adminPassword!@#`
+Publication Administrator | publicationAdministrator | `publicationAdministrator@pilcrow.dev` | `publicationadminPassword!@#`
+Publication Editor | publicationEditor | `publicationEditor@pilcrow.dev` | `editorPassword!@#`
+Review Coordinator for Submission | reviewCoordinator | `reviewCoordinator@pilcrow.dev` | `coordinatorPassword!@#`
+Reviewer for Submission | reviewer | `reviewer@pilcrow.dev` | `reviewerPassword!@#`
+Regular User | regularUser | `regularuser@pilcrow.dev` | `regularPassword!@#`
 
 Other users can be registered to the staging environment, but please note that these users and any data associated with them **may be wiped any time the code base is updated**.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -136,12 +136,12 @@ The users below are permanent on the test servers, and will not be deleted. Howe
 
 Name | Username | Login email | Login Password
 :---- | :---- | :---- | :----
-Application Administrator | applicationAdminUser | applicationadministrator@pilcrow.dev | adminPassword!@#
-Publication Administrator | publicationAdministrator | publicationAdministrator@pilcrow.dev | publicationadminPassword!@#
-Publication Editor | publicationEditor | publicationEditor@pilcrow.dev | editorPassword!@#
-Review Coordinator for Submission | reviewCoordinator | reviewCoordinator@pilcrow.dev | coordinatorPassword!@#
-Reviewer for Submission | reviewer | reviewer@pilcrow.dev | reviewerPassword!@#
-Regular User | regularUser | regularuser@pilcrow.dev | regularPassword!@#
+Application Administrator | applicationAdminUser | `applicationadministrator@pilcrow.dev` | adminPassword!@#
+Publication Administrator | publicationAdministrator | `publicationAdministrator@pilcrow.dev` | publicationadminPassword!@#
+Publication Editor | publicationEditor | `publicationEditor@pilcrow.dev` | editorPassword!@#
+Review Coordinator for Submission | reviewCoordinator | `reviewCoordinator@pilcrow.dev` | coordinatorPassword!@#
+Reviewer for Submission | reviewer | `reviewer@pilcrow.dev` | reviewerPassword!@#
+Regular User | regularUser | `regularuser@pilcrow.dev` | regularPassword!@#
 
 Other users can be registered to the staging environment, but please note that these users and any data associated with them **may be wiped any time the code base is updated**.
 


### PR DESCRIPTION
Introduced by the markdownlint upgrade, I didn't catch this before merging.