### PR TITLE
fix: downgrade dependency graphql/graphql-js to 16.6.0

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2965,9 +2965,9 @@ graphql-tag@^2.12.6:
     tslib "^2.1.0"
 
 graphql@^16.6.0:
-  version "16.7.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.7.1.tgz#11475b74a7bff2aefd4691df52a0eca0abd9b642"
-  integrity sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 happy-dom@^8.9.0:
   version "8.9.0"


### PR DESCRIPTION
This reverts commit 921a31507ccbf43df7c2fc9ebc14fcd28ec6a6b1.

A bug exists in graphql 16.7.1 that causes an error when quasar is running in development mode.   This doesn't affect the build or the compiled assets so it missed detection during the automated testing.  

Ref: https://github.com/graphql/graphql-js/issues/3925