### PR TITLE
chore(lando): upgrade lando appserver to php 8.2

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,7 @@
 name: pilcrow
 recipe: laravel
 config:
-  php: "8.1"
+  php: "8.2"
   composer_version: 2
   composer: []
   webroot: backend/public


### PR DESCRIPTION
Docker image has been upgraded to php 8.2 without issue and tests are now running from inside the built containers, so lando's version should ideally match the container version for good DX.