### PR TITLE
fix: Revert debugging code

### DIFF
--- a/client/test/cypress/support/index.js
+++ b/client/test/cypress/support/index.js
@@ -25,5 +25,4 @@ Cypress.on("uncaught:exception", (err) => {
     // failing the test
     return false
   }
-  return false
 })


### PR DESCRIPTION
This fixes a leftover line of debugging code that I forgot to remove from this commit: https://github.com/MESH-Research/Pilcrow/commit/20df267bcf69eaf8452651c797b38bcf09ffbb64#diff-1bf643980de446a3dd3732c24adafec075efd3ad9e0f80ad4e203b2a55ed5974

This code was partially reverted in this commit: https://github.com/MESH-Research/Pilcrow/commit/0571672b0f36d34ff56af60f9c467b4c63b39d5a