### PR TITLE
feat: Add backend protection from newly added comments for submissions out of review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ backend/vendor/**/*
 /vendor/
 /backend/storage/
 docker-compose.override.y*ml
+backend/_lighthouse_ide_helper.php
+backend/programmatic-types.graphql
+backend/schema-directives.graphql

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -179,7 +179,6 @@ class SubmissionPolicy
         }
 
         //Check that the user has any role on the submission
-
         if ($user->hasSubmissionRole('*', $submission->id)) {
             return true;
         }
@@ -201,7 +200,6 @@ class SubmissionPolicy
         }
 
         //Check that the user has any role on the submission
-
         if ($user->hasSubmissionRole('*', $submission->id)) {
             return true;
         }

--- a/backend/app/Rules/SubmissionIsReviewable.php
+++ b/backend/app/Rules/SubmissionIsReviewable.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Models\Submission;
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class SubmissionIsReviewable implements ValidationRule, DataAwareRule
+{
+    /**
+     * All of the data under validation.
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Set the data under validation
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $submission = Submission::where('id', $this->data['input']['id'])->firstOrFail();
+        if ($submission->status !== Submission::UNDER_REVIEW) {
+            $fail('The submission is not in a reviewable state.');
+        }
+    }
+}

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -80,8 +80,8 @@ input InlineCommentHasManyInput {
     create: [CreateInlineCommentInput!]
         @rules(
             apply: [
-                "App\\Rules\\InlineCommentIdValidity"
                 "App\\Rules\\SubmissionIsReviewable"
+                "App\\Rules\\InlineCommentIdValidity"
             ]
         )
     update: [UpdateInlineCommentInput!]

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -78,7 +78,12 @@ extend input UpdateSubmissionInput {
 
 input InlineCommentHasManyInput {
     create: [CreateInlineCommentInput!]
-        @rules(apply: ["App\\Rules\\InlineCommentIdValidity"])
+        @rules(
+            apply: [
+                "App\\Rules\\InlineCommentIdValidity"
+                "App\\Rules\\SubmissionIsReviewable"
+            ]
+        )
     update: [UpdateInlineCommentInput!]
 }
 
@@ -101,7 +106,12 @@ input UpdateInlineCommentInput {
 
 input OverallCommentHasManyInput {
     create: [CreateOverallCommentInput!]
-        @rules(apply: ["App\\Rules\\OverallCommentIdValidity"])
+        @rules(
+            apply: [
+                "App\\Rules\\OverallCommentIdValidity"
+                "App\\Rules\\SubmissionIsReviewable"
+            ]
+        )
     update: [UpdateOverallCommentInput!]
 }
 

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -330,7 +330,6 @@ class SubmissionCommentTest extends ApiTestCase
             $fragment[] = "$input: $$camelName";
             $variables[$camelName] = $variable ? $$camelName : null;
         }
-        print_r(implode("\n", $fragment));
 
         $graphQL =
             /** @lang GraphQL */
@@ -574,6 +573,7 @@ class SubmissionCommentTest extends ApiTestCase
         $this->rethrowGraphQLErrors();
         $user = $this->beSubmitter();
         $submission = $user->submissions->first();
+        $this->expectException(Error::class);
         $this->graphQL(
             'mutation AddInlineComment ($submission_id: ID!) {
                 updateSubmission(
@@ -581,6 +581,7 @@ class SubmissionCommentTest extends ApiTestCase
                         id: $submission_id,
                         inline_comments: {create: [{content:"Hello World", reply_to_id: null, parent_id: null}]}
                     }
+                ) {
                     id
                 }
             }',
@@ -588,6 +589,7 @@ class SubmissionCommentTest extends ApiTestCase
                 'submission_id' => $submission->id,
             ]
         );
+    }
 
     /**
      * @return void

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -570,11 +570,8 @@ class SubmissionCommentTest extends ApiTestCase
      */
     public function testSubmissionOutOfReviewRejectsNewInlineComments(): void
     {
-        $this->rethrowGraphQLErrors();
         $user = $this->beSubmitter();
         $submission = $user->submissions->first();
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Validation failed for the field [updateSubmission].');
         $this->graphQL(
             'mutation AddInlineComment ($submission_id: ID!) {
                 updateSubmission(
@@ -589,6 +586,11 @@ class SubmissionCommentTest extends ApiTestCase
             [
                 'submission_id' => $submission->id,
             ]
+        )
+        ->assertGraphQLErrorMessage('Validation failed for the field [updateSubmission].')
+        ->assertGraphQLValidationError(
+            'input.inline_comments.create.0',
+            'The submission is not in a reviewable state.'
         );
     }
 
@@ -597,7 +599,6 @@ class SubmissionCommentTest extends ApiTestCase
      */
     public function testSubmissionUnderReviewAcceptsNewInlineComments(): void
     {
-        $this->rethrowGraphQLErrors();
         $user = $this->beSubmitter();
         $submission = $user->submissions->first();
         $submission->status = Submission::UNDER_REVIEW;
@@ -642,11 +643,8 @@ class SubmissionCommentTest extends ApiTestCase
      */
     public function testSubmissionOutOfReviewRejectsNewOverallComments(): void
     {
-        $this->rethrowGraphQLErrors();
         $user = $this->beSubmitter();
         $submission = $user->submissions->first();
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Validation failed for the field [updateSubmission].');
         $this->graphQL(
             'mutation AddOverallComment ($submission_id: ID!) {
                 updateSubmission(
@@ -661,6 +659,11 @@ class SubmissionCommentTest extends ApiTestCase
             [
                 'submission_id' => $submission->id,
             ]
+        )
+        ->assertGraphQLErrorMessage('Validation failed for the field [updateSubmission].')
+        ->assertGraphQLValidationError(
+            'input.overall_comments.create.0',
+            'The submission is not in a reviewable state.'
         );
     }
 
@@ -669,7 +672,6 @@ class SubmissionCommentTest extends ApiTestCase
      */
     public function testSubmissionUnderReviewAcceptsNewOverallComments(): void
     {
-        $this->rethrowGraphQLErrors();
         $user = $this->beSubmitter();
         $submission = $user->submissions->first();
         $submission->status = Submission::UNDER_REVIEW;

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -579,7 +579,7 @@ class SubmissionCommentTest extends ApiTestCase
                 updateSubmission(
                     input: {
                         id: $submission_id,
-                        inline_comments: {create: [{content:"Hello World", reply_to_id: null, parent_id: null}]}
+                        inline_comments: {create: [{content:"Hello World", reply_to_id: null, parent_id: null, from: 120, to: 130 }]}
                     }
                 ) {
                     id

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -8,7 +8,6 @@ use App\Models\OverallComment;
 use App\Models\StyleCriteria;
 use App\Models\Submission;
 use App\Models\User;
-use GraphQL\Error\Error;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\ApiTestCase;

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -143,7 +143,7 @@ abstract class TestCase extends BaseTestCase
         }
 
         foreach ($json['errors'] as $index => $error) {
-            unset($json['errors'][$index]['trace']);
+            unset($json['errors'][$index]['extensions']['trace']);
         }
 
         return $json;


### PR DESCRIPTION
This prevents new inline and overall comment creation mutations from being ran on the backend for submissions whose status is not "Under Review".

Bonus:

* Adds files generated from `php artisan lighthouse:ide-helper` to `.gitignore`
    * Read more: https://lighthouse-php.com/6/testing/phpunit.html#assertions
* Fixes the `unsetJsonTrace` method in `backend/tests/TestCase.php`

Closes #1791 