### PR TITLE
fix: Restore icon picker functionality

### DIFF
--- a/client/src/components/dialogs/SelectIconDialog.vue
+++ b/client/src/components/dialogs/SelectIconDialog.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { QIconPicker } from "@quasar/quasar-ui-qiconpicker/src/index"
+import { QIconPicker } from "@quasar/quasar-ui-qiconpicker"
 import { useDialogPluginComponent } from "quasar"
 import materialIcons from '@quasar/quasar-ui-qiconpicker/src/components/icon-set/material-icons'
 import { ref } from "vue"

--- a/client/src/components/dialogs/SelectIconDialog.vue
+++ b/client/src/components/dialogs/SelectIconDialog.vue
@@ -10,7 +10,7 @@
         />
         <q-icon-picker
           :model-value="props.icon"
-          icon-set="material-icons"
+          :icons="materialIcons.icons"
           style="height: 300px"
           :filter="filter"
           @update:model-value="onSave"
@@ -21,8 +21,9 @@
 </template>
 
 <script setup>
-import { QIconPicker } from "@quasar/quasar-ui-qiconpicker"
+import { QIconPicker } from "@quasar/quasar-ui-qiconpicker/src/index"
 import { useDialogPluginComponent } from "quasar"
+import materialIcons from '@quasar/quasar-ui-qiconpicker/src/components/icon-set/material-icons'
 import { ref } from "vue"
 
 const filter = ref("")

--- a/client/src/components/molecules/FormActions.vue
+++ b/client/src/components/molecules/FormActions.vue
@@ -69,7 +69,7 @@ const saveClassList = computed(() => {
     saved: "bg-positive text-white",
     dirty: "bg-accent text-white",
   }
-  return classes[state.value] ?? "bg-grey-3"
+  return classes[state.value] ?? "bg-grey-8 text-white"
 })
 const saveCyAttr = computed(() => {
   return (


### PR DESCRIPTION
This pull request:

* Fixes the icon picker on the publication config page for choosing the icon of style criteria

Bonus:

* Fixes a contrast issue for the "saving" button that briefly appears after choosing to save an icon for a style criteria

Closes #1835 