### PR TITLE
refactor: Change submit buttons

### DIFF
--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -764,10 +764,11 @@
         "answer": "A publication may not appear here if the publication is:",
         "reason_1": "not accepting submissions at this time",
         "reason_2": "not publicly visible"
-      }
+      },
+      "action": "Submit New Submission"
     },
     "create": {
-      "heading": "Submit a Work",
+      "heading": "Create Submission",
       "publication_dropdown": "Publication",
       "success": "This submission has been submitted for review.",
       "failure": "An error occurred while attempting to create the submission.",

--- a/client/src/pages/Publication/PublicationHomePage.vue
+++ b/client/src/pages/Publication/PublicationHomePage.vue
@@ -37,8 +37,9 @@
       <q-btn
         v-if="publication.is_accepting_submissions"
         color="primary"
+        class="q-mt-lg"
         :to="{ name: 'submission:create', params: { id: publication.id } }"
-        >{{ $t("submissions.create.heading") }}</q-btn
+        >{{ $t("submissions.new.action") }}</q-btn
       >
     </div>
   </article>

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -51,8 +51,8 @@
         <q-btn
           v-if="selectedPublication"
           color="primary"
-          :label="$t(`submissions.create.heading`)"
-          class="q-mt-md"
+          :label="$t(`submissions.new.action`)"
+          class="q-mt-lg"
           :to="{
             name: 'submission:create',
             params: { id: selectedPublication.value },


### PR DESCRIPTION
This pull request:

* Changes the text for the "Submit a Work" buttons so that they read "Submit New Submission" instead
* Adds some whitespace above those buttons
* Changes the page title that reads "Submit a Work" to "Create Submission"

Closes #1914 