### PR TITLE
feat: Improve inconsistent menu and naming

### DIFF
--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -41,20 +41,20 @@
             :aria-label="$t('header.account_dropdown_aria')"
             data-cy="headerUserMenu"
           >
-            <q-item clickable data-cy="link_my_account" to="/account/profile">
+            <q-item clickable to="/account/metadata">
               <q-item-section avatar>
                 <q-icon name="account_circle" />
               </q-item-section>
               <q-item-section>
-                {{ $t("header.login_and_password") }}
+                {{ $t("header.profile") }}
               </q-item-section>
             </q-item>
-            <q-item clickable to="/account/metadata">
+            <q-item clickable data-cy="link_my_account" to="/account/profile">
               <q-item-section avatar>
-                <q-icon name="contact_page" />
+                <q-icon name="o_settings" />
               </q-item-section>
               <q-item-section>
-                {{ $t("header.profile") }}
+                {{ $t("header.login_and_password") }}
               </q-item-section>
             </q-item>
             <div v-if="isAppAdmin">

--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -46,7 +46,15 @@
                 <q-icon name="account_circle" />
               </q-item-section>
               <q-item-section>
-                {{ $t("header.account_link") }}
+                {{ $t("header.login_and_password") }}
+              </q-item-section>
+            </q-item>
+            <q-item clickable to="/account/metadata">
+              <q-item-section avatar>
+                <q-icon name="contact_page" />
+              </q-item-section>
+              <q-item-section>
+                {{ $t("header.profile") }}
               </q-item-section>
             </q-item>
             <div v-if="isAppAdmin">

--- a/client/src/components/forms/AccountProfileForm.vue
+++ b/client/src/components/forms/AccountProfileForm.vue
@@ -2,7 +2,7 @@
   <q-form data-cy="vueAccount" @submit="onSubmit">
     <v-q-wrap t-prefix="account.account.fields" @vqupdate="updateVQ">
       <form-section first-section>
-        <template #header>{{ $t(`account.profile.account_information`) }}</template>
+        <template #header>{{ $t(`account.profile.login_and_password`) }}</template>
         <v-q-input
           ref="usernameInput"
           :v="v$.username"

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -164,7 +164,6 @@
       "update_form_internal": "Error processing result. Please try again later.",
       "unknown": "An unexpected error occurred while updating."
     },
-    "header": "My Account",
     "preview_link": "Preview Public Profile",
     "submissions_reviewed": "Submissions Reviewed",
     "submissions_created": "Submissions Created",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -122,7 +122,8 @@
     "maxLength": "The maximum length has been exceeded."
   },
   "header": {
-    "account_link": "My Account",
+    "login_and_password": "Login and Password",
+    "profile": "Profile",
     "dashboard": "Dashboard",
     "menu_button_aria": "Show/hide navigation sidebar",
     "publications": "Publications",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -208,7 +208,7 @@
       }
     },
     "profile": {
-      "account_information": "Account Information",
+      "login_and_password": "Login and Password",
       "update_password": "Update Password",
       "section_details": "Profile Details",
       "section_personal": "Personal Details",
@@ -331,8 +331,8 @@
   },
   "dashboard": {
     "welcome_message": "Welcome, {label}",
-    "account_info": "Account Information",
     "profile_details": "Profile Details",
+    "login_and_password": "Login and Password",
     "guide": "guide",
     "guide_question": "New to Pilcrow?",
     "guide_call_to_action": "Learn more in our {link}."

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -210,7 +210,7 @@
     "profile": {
       "login_and_password": "Login and Password",
       "update_password": "Update Password",
-      "section_details": "Profile Details",
+      "section_details": "Profile",
       "section_personal": "Personal Details",
       "section_biography": "Biography",
       "section_social_media": "Social Media Profiles",
@@ -331,8 +331,8 @@
   },
   "dashboard": {
     "welcome_message": "Welcome, {label}",
-    "profile_details": "Profile Details",
     "login_and_password": "Login and Password",
+    "profile": "Profile",
     "guide": "guide",
     "guide_question": "New to Pilcrow?",
     "guide_call_to_action": "Learn more in our {link}."

--- a/client/src/layouts/Account/AccountLayout.vue
+++ b/client/src/layouts/Account/AccountLayout.vue
@@ -62,7 +62,7 @@ const { t } = useI18n()
 const items = [
   {
     icon: "account_circle",
-    label: t(`account.profile.account_information`),
+    label: t(`account.profile.login_and_password`),
     url: "/account/profile",
   },
   {

--- a/client/src/layouts/Account/AccountLayout.vue
+++ b/client/src/layouts/Account/AccountLayout.vue
@@ -62,13 +62,13 @@ const { t } = useI18n()
 const items = [
   {
     icon: "account_circle",
-    label: t(`account.profile.login_and_password`),
-    url: "/account/profile",
-  },
-  {
-    icon: "contact_page",
     label: t(`account.profile.section_details`),
     url: "/account/metadata",
+  },
+  {
+    icon: "o_settings",
+    label: t(`account.profile.login_and_password`),
+    url: "/account/profile",
   },
 ]
 

--- a/client/src/pages/DashboardPage.vue
+++ b/client/src/pages/DashboardPage.vue
@@ -26,11 +26,11 @@
             :class="`${$q.screen.width < 600 ? 'q-pl-lg' : ''}`"
             :vertical="$q.screen.width < 600 ? true : false"
           >
+            <q-btn flat icon="account_circle" to="/account/metadata">{{
+              $t(`dashboard.profile`)
+            }}</q-btn>
             <q-btn flat icon="o_settings" to="/account/profile">{{
               $t(`dashboard.login_and_password`)
-            }}</q-btn>
-            <q-btn flat icon="o_contact_page" to="/account/metadata">{{
-              $t(`dashboard.profile`)
             }}</q-btn>
             <q-btn flat icon="mdi-logout" to="/logout">{{
               $t(`auth.logout`)

--- a/client/src/pages/DashboardPage.vue
+++ b/client/src/pages/DashboardPage.vue
@@ -27,7 +27,7 @@
             :vertical="$q.screen.width < 600 ? true : false"
           >
             <q-btn flat icon="o_settings" to="/account/profile">{{
-              $t(`dashboard.account_info`)
+              $t(`dashboard.login_and_password`)
             }}</q-btn>
             <q-btn flat icon="o_contact_page" to="/account/metadata">{{
               $t(`dashboard.profile_details`)

--- a/client/src/pages/DashboardPage.vue
+++ b/client/src/pages/DashboardPage.vue
@@ -30,7 +30,7 @@
               $t(`dashboard.login_and_password`)
             }}</q-btn>
             <q-btn flat icon="o_contact_page" to="/account/metadata">{{
-              $t(`dashboard.profile_details`)
+              $t(`dashboard.profile`)
             }}</q-btn>
             <q-btn flat icon="mdi-logout" to="/logout">{{
               $t(`auth.logout`)

--- a/client/test/cypress/integration/header.cy.js
+++ b/client/test/cypress/integration/header.cy.js
@@ -20,7 +20,7 @@ describe("Header", () => {
     cy.get("header").contains("regularUser").click()
 
     cy.dataCy("headerUserMenu").within(() => {
-      cy.contains("My Account").should("have.attr", "href", "/account/profile")
+      cy.contains("Login and Password").should("have.attr", "href", "/account/profile")
       cy.contains("Logout").click()
     })
 


### PR DESCRIPTION
This pull request:

* Changes "Account Info" to "Login and Password"
* Changes "Profile Info" to "Profile"
* Removes "My Account" from main dropdown menu and adds "Profile" and "Login and Password" as dropdown menu options
* Makes icon usage consistent for these options
* Flips the order of these options so that Profile is first

Closes #1929
