### PR TITLE
fix: Address inconsistent appearance of large lists

### DIFF
--- a/client/src/components/atoms/UserListBasicItem.vue
+++ b/client/src/components/atoms/UserListBasicItem.vue
@@ -19,10 +19,6 @@
         {{ user.email }}
       </q-item-label>
     </q-item-section>
-
-    <q-item-section side top>
-      <q-item-label caption> meta </q-item-label>
-    </q-item-section>
   </q-item>
 </template>
 

--- a/client/src/components/molecules/UserListBasic.vue
+++ b/client/src/components/molecules/UserListBasic.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-list bordered :data-cy="dataCy" role="list">
+  <q-list :data-cy="dataCy" role="list">
     <user-list-basic-item
       v-for="(user, index) in users"
       :key="user.id"

--- a/client/src/pages/Admin/UsersIndex.vue
+++ b/client/src/pages/Admin/UsersIndex.vue
@@ -1,5 +1,4 @@
 <template>
-  <div>
     <h2 class="q-pl-lg">All Users</h2>
     <div v-if="users.length">
       <user-list-basic
@@ -16,7 +15,6 @@
         :max="lastPage"
       />
     </div>
-  </div>
 </template>
 
 <script setup>

--- a/client/src/pages/Publication/PublicationsIndexPage.vue
+++ b/client/src/pages/Publication/PublicationsIndexPage.vue
@@ -1,42 +1,41 @@
+
 <template>
-  <div>
-    <h2 class="q-px-lg">{{ $t("publication.entity", { count: 2 }) }}</h2>
-    <section class="q-px-lg">
-      <div v-if="!loading" class="column q-gutter-md items-center">
-        <q-list
-          v-if="publications.length !== 0"
-          class="full-width"
-          separator
-          data-cy="publications_list"
+  <h2 class="q-px-lg">{{ $t("publication.entity", { count: 2 }) }}</h2>
+  <section>
+    <div v-if="!loading" class="column items-center">
+      <q-list
+        v-if="publications.length !== 0"
+        class="full-width"
+        separator
+        data-cy="publications_list"
+      >
+        <q-item
+          v-for="publication in publications"
+          :key="publication.id"
+          class="q-px-lg"
+          :to="destRoute(publication.id)"
         >
-          <q-item
-            v-for="publication in publications"
-            :key="publication.id"
-            class="q-py-md"
-            :to="destRoute(publication.id)"
-          >
-            <q-item-section>
-              <q-item-label>
-                {{ publication.name }}
-              </q-item-label>
-              <q-item-label caption>
-                {{ strip(publication.home_page_content) }}
-              </q-item-label>
-            </q-item-section>
-          </q-item>
-        </q-list>
-        <q-pagination
-          v-if="paginatorInfo"
-          v-bind="binds"
-          class="col"
-          v-on="listeners"
-        />
-      </div>
-      <div v-else class="spinner">
-        <q-spinner color="primary" />
-      </div>
-    </section>
-  </div>
+          <q-item-section>
+            <q-item-label>
+              {{ publication.name }}
+            </q-item-label>
+            <q-item-label caption>
+              {{ strip(publication.home_page_content) }}
+            </q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+      <q-pagination
+        v-if="paginatorInfo"
+        v-bind="binds"
+        class="q-pa-lg"
+        v-on="listeners"
+      />
+    </div>
+    <div v-else class="spinner">
+      <q-spinner color="primary" />
+    </div>
+  </section>
 </template>
 
 <script setup>


### PR DESCRIPTION
This pull request:

* Ensures the existing large lists on the Publications page and All Users page have consistent whitespace usage and interactive area
* Ensures users lists on the All Users page and the Submission Details have consistent structure and whitespace usage

> [!NOTE]
> User lists had their [borders removed October 3rd, 2022](https://github.com/MESH-Research/Pilcrow/commit/fcaa3332482c52c633ac65debd2917e4dc638ef9#diff-d6baba844d3d6ed6adb7f9c6917ce8ffdc396bc972f82625d137ef5c5113254b) and their [separators removed December 14th, 2022](https://github.com/MESH-Research/Pilcrow/commit/86e613503ccb746b187a98f50bc6665011598353#diff-d6baba844d3d6ed6adb7f9c6917ce8ffdc396bc972f82625d137ef5c5113254b
). The Style Guide was not updated to account for this. I'm not exactly sure what the conversation around this change was at the time but I suspect it's because the borderless appearance looks better than the bordered appearance given the evolution of the application's interface. I made the user list on the All Users page use the borderless/separator-less style. Once this is merged into master, I will update [the Style Guide](https://github.com/MESH-Research/Pilcrow/wiki/Style-Guide#user-lists) accordingly. 

Closes #1907 