### PR TITLE
feat: Hide status changing from reviewers

### DIFF
--- a/client/src/components/SubmissionTableActions.vue
+++ b/client/src/components/SubmissionTableActions.vue
@@ -70,7 +70,7 @@
         </q-tooltip>
       </q-item>
       <q-item
-        v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
+        v-if="!statusChangingDisabledByRole"
         data-cy="change_status"
         clickable
         :disable="statusChangingDisabledByState"
@@ -81,7 +81,7 @@
           </q-item-label>
         </q-item-section>
         <q-tooltip
-          v-if="submission.status == 'RESUBMISSION_REQUESTED'"
+          v-if="statusChangingDisabledByState"
           anchor="top middle"
           self="bottom middle"
           :offset="[10, 10]"

--- a/client/src/components/SubmissionTableActions.vue
+++ b/client/src/components/SubmissionTableActions.vue
@@ -70,13 +70,10 @@
         </q-tooltip>
       </q-item>
       <q-item
+        v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
         data-cy="change_status"
         clickable
-        :disable="
-          submission.status == 'REJECTED' ||
-          submission.status == 'RESUBMISSION_REQUESTED' ||
-          submission.status == 'DELETED'
-        "
+        :disable="statusChangingDisabledByState"
       >
         <q-item-section data-cy="change_status_item_section">
           <q-item-label>
@@ -84,11 +81,7 @@
           </q-item-label>
         </q-item-section>
         <q-tooltip
-          v-if="
-            submission.status == 'DELETED' ||
-            submission.status == 'REJECTED' ||
-            submission.status == 'RESUBMISSION_REQUESTED'
-          "
+          v-if="submission.status == 'RESUBMISSION_REQUESTED'"
           anchor="top middle"
           self="bottom middle"
           :offset="[10, 10]"
@@ -246,13 +239,18 @@
 <script setup>
 import ConfirmStatusChangeDialog from "../components/dialogs/ConfirmStatusChangeDialog.vue"
 import { useQuasar } from "quasar"
-import { useSubmissionExport } from "src/use/guiElements.js"
+import {
+  useSubmissionExport,
+  useStatusChangeControls,
+} from "src/use/guiElements.js"
 import { ref } from "vue"
 const { dialog } = useQuasar()
 
 const submissionRef = ref(props.submission)
 const { isDisabledByRole, isDisabledByState } =
   useSubmissionExport(submissionRef)
+const { statusChangingDisabledByRole, statusChangingDisabledByState } =
+  useStatusChangeControls(submissionRef)
 
 const props = defineProps({
   submission: {
@@ -264,6 +262,7 @@ const props = defineProps({
     default: "",
   },
 })
+
 function cannotAccessSubmission(submission) {
   const nonreviewableStates = new Set([
     "DRAFT",

--- a/client/src/components/atoms/SubmissionToolbar.vue
+++ b/client/src/components/atoms/SubmissionToolbar.vue
@@ -34,7 +34,7 @@
       </q-toolbar-title>
 
       <q-btn-dropdown
-        v-if="submission.status != 'DELETED'"
+        v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
         :label="$t(`submission.toolbar.status_options`)"
         flat
         menu-anchor="bottom right"
@@ -52,7 +52,7 @@
           >
           </q-btn>
         </div>
-        
+
         <q-btn-group
           v-else-if="
             submission.status != 'AWAITING_REVIEW' &&
@@ -132,9 +132,7 @@
         </q-btn-group>
 
         <q-btn-group
-          v-if="
-          submission.status == 'ACCEPTED_AS_FINAL'
-          "
+          v-if="submission.status == 'ACCEPTED_AS_FINAL'"
           data-cy="decision_options"
           flat
           square
@@ -180,7 +178,6 @@
           >
           </q-btn>
         </q-btn-group>
-
       </q-btn-dropdown>
       <q-icon
         v-if="isDisabledByRole || isDisabledByState"
@@ -244,7 +241,10 @@
 <script setup>
 import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
 import { useQuasar } from "quasar"
-import { useSubmissionExport } from "src/use/guiElements.js"
+import {
+  useSubmissionExport,
+  useStatusChangeControls,
+} from "src/use/guiElements.js"
 import { ref } from "vue"
 
 const { dialog } = useQuasar()
@@ -252,6 +252,8 @@ const { dialog } = useQuasar()
 const submissionRef = ref(props.submission)
 const { isDisabledByRole, isDisabledByState } =
   useSubmissionExport(submissionRef)
+const { statusChangingDisabledByRole, statusChangingDisabledByState } =
+  useStatusChangeControls(submissionRef)
 
 const props = defineProps({
   // Drawer status

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -82,6 +82,9 @@ export const CURRENT_USER_SUBMISSIONS = gql`
         review_coordinators {
           ...relatedUserFields
         }
+        reviewers {
+          ...relatedUserFields
+        }
         submitters {
           ...relatedUserFields
         }

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -66,6 +66,8 @@ export function useStatusChangeControls(submission) {
   })
 
   const statusChangingDisabledStates = [
+    "REJECTED",
+    "RESUBMISSION_REQUESTED",
     "DELETED"
   ]
 

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -55,6 +55,32 @@ export function useFeedbackMessages(overrideDefaults = {}) {
   return { newMessage, newStatusMessage }
 }
 
+export function useStatusChangeControls(submission) {
+  const { isReviewer } = useCurrentUser()
+
+  const statusChangingDisabledByRole = computed(() => {
+    if (!submission.value) {
+      return true
+    }
+    return isReviewer(submission.value)
+  })
+
+  const statusChangingDisabledStates = [
+    "DELETED"
+  ]
+
+  const statusChangingDisabledByState = computed(() => {
+    if (!submission.value) {
+      return true
+    }
+    return statusChangingDisabledStates.includes(submission.value.status)
+  })
+
+  return {
+    statusChangingDisabledByRole, statusChangingDisabledByState
+  }
+}
+
 export function useSubmissionExport(submission) {
   const {
     isAppAdmin,

--- a/client/src/use/user.js
+++ b/client/src/use/user.js
@@ -48,6 +48,11 @@ export function useCurrentUser() {
       return o.id == currentUser.value.id
     })
   }
+  const isReviewer = (submission) => {
+    return submission?.reviewers?.some((o) => {
+      return o.id == currentUser.value.id
+    })
+  }
   const isReviewCoordinator = (submission) => {
     return submission?.review_coordinators?.some((o) => {
       return o.id == currentUser.value.id
@@ -72,6 +77,7 @@ export function useCurrentUser() {
     abilities,
     isAppAdmin,
     isSubmitter,
+    isReviewer,
     isReviewCoordinator,
     isEditor,
     isPublicationAdmin,

--- a/client/test/cypress/integration/reviewspage.cy.js
+++ b/client/test/cypress/integration/reviewspage.cy.js
@@ -89,9 +89,7 @@ describe("Reviews Page", () => {
       .parent("tr")
       .findCy("submission_actions")
       .click()
-    cy.dataCy("change_status").should("have.class", "disabled")
-    cy.dataCy("change_status_item_section").trigger("mouseenter")
-    cy.dataCy("cannot_change_submission_status_tooltip")
+    cy.dataCy("change_status").should("not.exist")
   })
 
   it("should deny a reviewer from changing the status of rejected submissions", () => {
@@ -101,9 +99,7 @@ describe("Reviews Page", () => {
     cy.dataCy("reviewer_table").contains("Records per page").next().click()
     cy.get("[role='listbox']").contains("All").click()
     cy.contains("Rejected").parent("tr").findCy("submission_actions").click()
-    cy.dataCy("change_status").should("have.class", "disabled")
-    cy.dataCy("change_status_item_section").trigger("mouseenter")
-    cy.dataCy("cannot_change_submission_status_tooltip")
+    cy.dataCy("change_status").should("not.exist")
   })
 
   it("should deny a reviewer from accessing rejected submissions", () => {
@@ -130,11 +126,7 @@ describe("Reviews Page", () => {
       .parent("tr")
       .findCy("submission_actions")
       .click()
-    cy.dataCy("change_status").should("have.class", "disabled")
-    cy.dataCy("change_status_item_section").trigger("mouseenter")
-    cy.dataCy("cannot_change_submission_status_tooltip")
-    cy.dataCy("change_status_item_section").trigger("click")
-    cy.dataCy("change_status_dropdown").should("not.be.visible")
+    cy.dataCy("change_status").should("not.exist")
   })
 
   it("should deny a reviewer from accessing submissions requested for resubmission", () => {

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -418,6 +418,13 @@ describe("Submissions Review", () => {
     cy.checkA11y(null, null, a11yLogViolations)
   })
 
+  it("does not show status changing options for reviewers", () => {
+    cy.task("resetDb")
+    cy.login({ email: "reviewer@pilcrow.dev" })
+    cy.visit("submission/108/review")
+    cy.dataCy("status-dropdown").should("not.exist")
+  })
+
   it("shows the correct status change options for submissions marked as ACCEPTED_AS_FINAL", () => {
     cy.task("resetDb")
     cy.login({ email: "reviewcoordinator@pilcrow.dev" })


### PR DESCRIPTION
This pull request 

* Hides the "Status Options" button on the Review page for reviewers
* Hides the "Change Status" option within submission table action menus for reviewers 

Closes #1916 

> [!NOTE]
> I discovered faulty behavior as far as status changing and [reported it here](https://app.zenhub.com/workspaces/pilcrow-development-5ff39ba363391e0019713c87/issues/gh/mesh-research/pilcrow/1916#issuecomment-1702876080).