### PR TITLE
feat: Change default content for publication home pages and create submission pages

### DIFF
--- a/backend/database/factories/PublicationFactory.php
+++ b/backend/database/factories/PublicationFactory.php
@@ -71,7 +71,7 @@ class PublicationFactory extends Factory
     private function makeNewSubmissionContent()
     {
         return "<p>This is an example of content from the publication that's displayed to users when " .
-            "they start the creation process for a new submission. This gives the publication an opportunity " .
-            "to brief the user with guidelines and expectations for the peer review process. </p>";
+            'they start the creation process for a new submission. This gives the publication an opportunity ' .
+            'to brief the user with guidelines and expectations for the peer review process. </p>';
     }
 }

--- a/backend/database/factories/PublicationFactory.php
+++ b/backend/database/factories/PublicationFactory.php
@@ -26,7 +26,7 @@ class PublicationFactory extends Factory
             'name' => $this->faker->unique()->company(),
             'is_publicly_visible' => true,
             'home_page_content' => $this->makeHomePageContent(),
-            'new_submission_content' => $this->faker->paragraphs(2, true),
+            'new_submission_content' => $this->makeNewSubmissionContent(),
         ];
     }
 
@@ -50,18 +50,28 @@ class PublicationFactory extends Factory
     private function makeHomePageContent()
     {
         return "<h3>Publication Home Page</h3> <p>This is an example of a publication's home page content. " .
-        'This is displayed to users who view the home page of a publication. </p>' .
-        "<p>This is usually a good place to describe a publication's focus, goals, team, etc. </p> " .
-        '<p>This can be written by someone managing the publication by performing the following steps:</p> <ol>' .
-        '<li>Log in as a user with sufficient publication-managing privileges. <ul>' .
-            '<li>This can be an Application Admin or a Publication Admin of a publication. </li></ul></li>' .
-        '<li>Visit the Publications page. </li>' .
-        '<li>From the list of publications, select the publication you wish to modify. </li>' .
-        "<li>Click the 'Configure Publication' button. </li>" .
-        "<li>Click the 'Page Content' menu item. </li>" .
-        "<li>Select the 'Home Page' item from the drop down menu. </li>" .
-        '<li>Edit the text in the text area. </li>' .
-        "<li>When finished, click the 'Save' button. </li>" .
-        '</ol><p>Page content will be rendered as HTML. </p>';
+            'This is displayed to users who view the home page of a publication. </p>' .
+            "<p>This is usually a good place to describe a publication's focus, goals, team, etc. </p> " .
+            '<p>This can be written by someone managing the publication by performing the following steps:</p> <ol>' .
+            '<li>Log in as a user with sufficient publication-managing privileges. <ul>' .
+                '<li>This can be an Application Admin or a Publication Admin of a publication. </li></ul></li>' .
+            '<li>Visit the Publications page. </li>' .
+            '<li>From the list of publications, select the publication you wish to modify. </li>' .
+            "<li>Click the 'Configure Publication' button. </li>" .
+            "<li>Click the 'Page Content' menu item. </li>" .
+            "<li>Select the 'Home Page' item from the drop down menu. </li>" .
+            '<li>Edit the text in the text area. </li>' .
+            "<li>When finished, click the 'Save' button. </li>" .
+            '</ol><p>Page content will be rendered as HTML. </p>';
+    }
+
+    /**
+     * @return string
+     */
+    private function makeNewSubmissionContent()
+    {
+        return "<p>This is an example of content from the publication that's displayed to users when " .
+            "they start the creation process for a new submission. This gives the publication an opportunity " .
+            "to brief the user with guidelines and expectations for the peer review process. </p>";
     }
 }

--- a/backend/database/factories/PublicationFactory.php
+++ b/backend/database/factories/PublicationFactory.php
@@ -25,7 +25,7 @@ class PublicationFactory extends Factory
         return [
             'name' => $this->faker->unique()->company(),
             'is_publicly_visible' => true,
-            'home_page_content' => $this->faker->content(1),
+            'home_page_content' => $this->makeHomePageContent(),
             'new_submission_content' => $this->faker->paragraphs(2, true),
         ];
     }
@@ -42,5 +42,26 @@ class PublicationFactory extends Factory
                 'is_publicly_visible' => false,
             ];
         });
+    }
+
+    /**
+     * @return string
+     */
+    private function makeHomePageContent()
+    {
+        return "<h3>Publication Home Page</h3> <p>This is an example of a publication's home page content. " .
+        'This is displayed to users who view the home page of a publication. </p>' .
+        "<p>This is usually a good place to describe a publication's focus, goals, team, etc. </p> " .
+        '<p>This can be written by someone managing the publication by performing the following steps:</p> <ol>' .
+        '<li>Log in as a user with sufficient publication-managing privileges. <ul>' .
+            '<li>This can be an Application Admin or a Publication Admin of a publication. </li></ul></li>' .
+        '<li>Visit the Publications page. </li>' .
+        '<li>From the list of publications, select the publication you wish to modify. </li>' .
+        "<li>Click the 'Configure Publication' button. </li>" .
+        "<li>Click the 'Page Content' menu item. </li>" .
+        "<li>Select the 'Home Page' item from the drop down menu. </li>" .
+        '<li>Edit the text in the text area. </li>' .
+        "<li>When finished, click the 'Save' button. </li>" .
+        '</ol><p>Page content will be rendered as HTML. </p>';
     }
 }

--- a/client/src/pages/Publication/PublicationHomePage.vue
+++ b/client/src/pages/Publication/PublicationHomePage.vue
@@ -33,9 +33,9 @@
         v-html="publication.home_page_content"
       />
       <!--  eslint-enable vue/no-v-html -->
-
+    </div>
+    <div v-if="publication.is_accepting_submissions" class="row q-mb-md">
       <q-btn
-        v-if="publication.is_accepting_submissions"
         color="primary"
         class="q-mt-lg"
         :to="{ name: 'submission:create', params: { id: publication.id } }"


### PR DESCRIPTION
This changes the placeholder text on seeded publication home pages and create submission pages so that it is no longer lorem ipsum but plain English describing what the text represents. 

Closes #1915 