### PR TITLE
style: update tooltip background

### DIFF
--- a/client/src/css/app.sass
+++ b/client/src/css/app.sass
@@ -69,6 +69,7 @@ a[target="_blank"]::after
 
 .q-tooltip--style
     color: #fff
+    background: $dark-5
 
 .large-text-inputs
     .q-field--labeled

--- a/client/src/pages/SubmissionsPage.vue
+++ b/client/src/pages/SubmissionsPage.vue
@@ -27,15 +27,15 @@
           {{ $t(`submissions.new.description`) }}
 
           <q-icon name="info">
-            <q-tooltip class="q-pa-none">
-              <q-card class="bg-grey-8 q-pa-md">
+            <q-tooltip class="q-pa-md">
+              <div>
                 <strong>{{ $t(`submissions.new.tooltip.question`) }}</strong>
                 <p>{{ $t(`submissions.new.tooltip.answer`) }}</p>
                 <ul class="q-ma-none">
                   <li>{{ $t(`submissions.new.tooltip.reason_1`) }}</li>
                   <li>{{ $t(`submissions.new.tooltip.reason_2`) }}</li>
                 </ul>
-              </q-card>
+              </div>
             </q-tooltip>
           </q-icon>
         </p>


### PR DESCRIPTION
This pull request:

- darkens the background color on tooltips
- updates the contrast on tooltips to pass WCAG AAA guidelines with a 10.86:1 contrast ratio

Closes #1909 