### PR TITLE
fix: Reference to translated string

### DIFF
--- a/client/src/pages/Publication/Setup/UsersPage.vue
+++ b/client/src/pages/Publication/Setup/UsersPage.vue
@@ -13,7 +13,7 @@
       <template #avatar>
         <q-icon name="tips_and_updates" size="sm" />
       </template>
-      {{ $t("publication.setup_pages.problems.no_admin") }}
+      {{ $t("publication.setup_pages.problems.no_admins") }}
     </q-banner>
     <div class="column q-gutter-md q-mb-lg">
       <assigned-publication-users


### PR DESCRIPTION
This fixes a reference to the `i18n.js` file in Publication Setup > Users for publications that have no administrators . 

Closes #1966 