### PR TITLE
refactor: Remove color theming from VSCode Workspace file

### DIFF
--- a/pilcrow.code-workspace
+++ b/pilcrow.code-workspace
@@ -47,25 +47,6 @@
         "vitest.include": [
             "**/*.vitest.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"
         ],
-        "workbench.colorCustomizations": {
-            "activityBar.activeBackground": "#65c89b",
-            "activityBar.background": "#65c89b",
-            "activityBar.foreground": "#15202b",
-            "activityBar.inactiveForeground": "#15202b99",
-            "activityBarBadge.background": "#945bc4",
-            "activityBarBadge.foreground": "#e7e7e7",
-            "commandCenter.border": "#15202b99",
-            "sash.hoverBorder": "#65c89b",
-            "statusBar.background": "#42b883",
-            "statusBar.foreground": "#15202b",
-            "statusBarItem.hoverBackground": "#359268",
-            "statusBarItem.remoteBackground": "#42b883",
-            "statusBarItem.remoteForeground": "#15202b",
-            "titleBar.activeBackground": "#42b883",
-            "titleBar.activeForeground": "#15202b",
-            "titleBar.inactiveBackground": "#42b88399",
-            "titleBar.inactiveForeground": "#15202b99"
-        },
         "files.associations": {
             "*.yaml": "home-assistant"
         },


### PR DESCRIPTION
Remove color theming from the recently-added VSCode Workspace file