### PR TITLE
fix: eliminate random page refreshes on navigation

### DIFF
--- a/client/src/apollo/apollo-links.js
+++ b/client/src/apollo/apollo-links.js
@@ -8,7 +8,9 @@ const cookieXsrfToken = () => Cookies.get("XSRF-TOKEN")
 const fetchXsrfToken = async () => {
   return fetch("/sanctum/csrf-cookie", {
     credentials: "same-origin",
-  }).then(() => {
+  }).then(async (response) => {
+    //Read response text (even though its empty) to prevent Chrome from thinking there's an error b/c no one read the (empty) response body.
+    await response.text()
     const xsrfToken = cookieXsrfToken()
     return xsrfToken
   })

--- a/client/src/apollo/apollo-links.js
+++ b/client/src/apollo/apollo-links.js
@@ -9,7 +9,7 @@ const fetchXsrfToken = async () => {
   return fetch("/sanctum/csrf-cookie", {
     credentials: "same-origin",
   }).then(async (response) => {
-    //Read response text (even though its empty) to prevent Chrome from thinking there's an error b/c no one read the (empty) response body.
+    //Read response text (even though its empty) to prevent the browser from thinking there's an error b/c no one read the (empty) response body.
     await response.text()
     const xsrfToken = cookieXsrfToken()
     return xsrfToken


### PR DESCRIPTION
This PR (should) fix the issue with random refreshes during page navigations.  The cause *seems* to be that when the CSRF cookie is fetched, the response is a `204 No Content`.  Because we don't expect there to be content, we also don't read the body of the response.   Chrome apparently sees this as an error (https://stackoverflow.com/a/67276787/407726).  

Reproduction was sporadic however, so I'm not completely convinced this was/is the actual issue just yet.