### PR TITLE
build: Use more Cypress-compatible Node version

### DIFF
--- a/.lando.extras.yml
+++ b/.lando.extras.yml
@@ -3,9 +3,9 @@ cypress:
   template:
     services:
       cypress:
-        type: node:20
+        type: node:18
         overrides:
-          image: "cypress/base:20"
+          image: "cypress/base:18"
           environment:
             ELECTRON_EXTRA_LAUNCH_ARGS: "--force-prefers-reduced-motion"
     tooling:


### PR DESCRIPTION
This prevents errors related to Node 20 being (somehow) incompatible with the application's instance of Cypress.