### PR TITLE
fix: Automatically dismiss unverified email banner alert upon email verification

### DIFF
--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -111,6 +111,7 @@ export const ACCEPT_SUBMISSION_INVITE = gql`
 export const VERIFY_EMAIL = gql`
   mutation VerifyEmail($token: String!, $expires: String!) {
     verifyEmail(token: $token, expires: $expires) {
+      id
       email_verified_at
     }
   }

--- a/client/src/pages/VerifyEmail.vue
+++ b/client/src/pages/VerifyEmail.vue
@@ -52,10 +52,7 @@ import { useGraphErrors } from "src/use/errors"
 const status = ref("loading")
 const errorMessagesList = ref([])
 const { currentUser } = useCurrentUser()
-
-const { mutate: verifyEmail } = useMutation(VERIFY_EMAIL, {
-  refetchQueries: ["currentUser"],
-})
+const { mutate: verifyEmail } = useMutation(VERIFY_EMAIL)
 const { params } = useRoute()
 const { errorMessages, graphQLErrorCodes } = useGraphErrors()
 onMounted(async () => {


### PR DESCRIPTION
This pull request adds the missing `id` from the user data returned from the `VERIFY_EMAIL` mutation. This ID is necessary for the user entity in the cache to be automatically updated as documented here: https://v4.apollo.vuejs.org/guide-composable/mutation.html#updating-a-single-existing-entity 

This allows the user entity to be updated as soon as the mutation completes on the email verification page and dismisses the unverified email banner alert that would otherwise remain at the top of the page until the entity is updated another way, usually by page refresh.

Closes #1968 