### PR TITLE
feat: Add comment deletion

### DIFF
--- a/backend/app/GraphQL/Mutations/DeleteInlineComment.php
+++ b/backend/app/GraphQL/Mutations/DeleteInlineComment.php
@@ -11,8 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 final readonly class DeleteInlineComment
 {
     /**
-     * Delete an inline comment of a submission
-     * Force delete if it has replies; soft delete otherwise
+     * Soft delete an inline comment of a submission
      *
      * @param null $_
      * @param  array{id: string}  $args
@@ -27,11 +26,7 @@ final readonly class DeleteInlineComment
             throw new ClientException('Not Found', 'deleteInlineComment', 'COMMENT_NOT_FOUND');
         }
         try {
-            if ($inline_comment->replies->count() == 0) {
-                $inline_comment->forceDelete();
-            } else {
-                $inline_comment->delete();
-            }
+            $inline_comment->delete();
 
             return $inline_comment->submission;
         } catch (\Exception $e) {

--- a/backend/app/GraphQL/Mutations/DeleteInlineComment.php
+++ b/backend/app/GraphQL/Mutations/DeleteInlineComment.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\ClientException;
+use App\Models\InlineComment;
+use App\Models\Submission;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final readonly class DeleteInlineComment
+{
+    /**
+     * Delete an inline comment of a submission
+     * Force delete if it has replies; soft delete otherwise
+     *
+     * @param null $_
+     * @param  array{id: string}  $args
+     * @return \App\Models\Submission
+     * @throws \App\Exceptions\ClientException
+     */
+    public function delete(null $_, array $args): Submission
+    {
+        try {
+            $inline_comment = InlineComment::findOrFail($args['comment_id']);
+        } catch (ModelNotFoundException $e) {
+            throw new ClientException('Not Found', 'deleteInlineComment', 'COMMENT_NOT_FOUND');
+        }
+        try {
+            if ($inline_comment->replies->count() == 0) {
+                $inline_comment->forceDelete();
+            } else {
+                $inline_comment->delete();
+            }
+
+            return $inline_comment->submission;
+        } catch (\Exception $e) {
+            throw new ClientException('Error', 'deleteInlineComment', 'UNABLE_TO_DELETE_COMMENT');
+        }
+    }
+}

--- a/backend/app/GraphQL/Mutations/DeleteOverallComment.php
+++ b/backend/app/GraphQL/Mutations/DeleteOverallComment.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\ClientException;
+use App\Models\OverallComment;
+use App\Models\Submission;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final readonly class DeleteOverallComment
+{
+    /**
+     * Delete an overall comment of a submission
+     * Force delete if it has replies; soft delete otherwise
+     *
+     * @param null $_
+     * @param  array{id: string}  $args
+     * @return \App\Models\Submission
+     * @throws \App\Exceptions\ClientException
+     */
+    public function delete(null $_, array $args): Submission
+    {
+        try {
+            $overall_comment = OverallComment::findOrFail($args['comment_id']);
+        } catch (ModelNotFoundException $e) {
+            throw new ClientException('Not Found', 'deleteOverallComment', 'COMMENT_NOT_FOUND');
+        }
+        try {
+            if ($overall_comment->replies->count() == 0) {
+                $overall_comment->forceDelete();
+            } else {
+                $overall_comment->delete();
+            }
+
+            return $overall_comment->submission;
+        } catch (\Exception $e) {
+            throw new ClientException('Error', 'deleteOverallComment', 'UNABLE_TO_DELETE_COMMENT');
+        }
+    }
+}

--- a/backend/app/GraphQL/Mutations/DeleteOverallComment.php
+++ b/backend/app/GraphQL/Mutations/DeleteOverallComment.php
@@ -11,8 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 final readonly class DeleteOverallComment
 {
     /**
-     * Delete an overall comment of a submission
-     * Force delete if it has replies; soft delete otherwise
+     * Soft delete an overall comment of a submission
      *
      * @param null $_
      * @param  array{id: string}  $args
@@ -27,11 +26,7 @@ final readonly class DeleteOverallComment
             throw new ClientException('Not Found', 'deleteOverallComment', 'COMMENT_NOT_FOUND');
         }
         try {
-            if ($overall_comment->replies->count() == 0) {
-                $overall_comment->forceDelete();
-            } else {
-                $overall_comment->delete();
-            }
+            $overall_comment->delete();
 
             return $overall_comment->submission;
         } catch (\Exception $e) {

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -110,6 +110,7 @@ class InlineComment extends BaseModel
                 if ($this->reply_to_id) {
                     return [];
                 }
+
                 return $this->trashed() ? [] : json_decode($attributes['style_criteria']);
             }
         );

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -107,6 +107,9 @@ class InlineComment extends BaseModel
     {
         return Attribute::make(
             get: function (mixed $value, array $attributes) {
+                if ($this->reply_to_id) {
+                    return [];
+                }
                 return $this->trashed() ? [] : json_decode($attributes['style_criteria']);
             }
         );

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -52,11 +52,16 @@ class InlineComment extends BaseModel
      */
     public function replies(): HasMany
     {
-        return $this->hasMany(InlineComment::class, 'parent_id');
+        $thread_replies = $this->hasMany(InlineComment::class, 'parent_id');
+        if ($thread_replies->count() > 0) {
+            return $thread_replies;
+        } else {
+            return $this->hasMany(InlineComment::class, 'reply_to_id');
+        }
     }
 
     /**
-      * The creator of the inline comment
+     * The creator of the inline comment
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -76,17 +81,17 @@ class InlineComment extends BaseModel
     }
 
     /**
-     * @return Attribute
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     protected function username(): Attribute
     {
         return Attribute::make(
-            get: fn (int $value) => $this->trashed() ? "" : $value,
+            get: fn (int $value) => $this->trashed() ? '' : $value,
         );
     }
 
     /**
-     * @return Attribute
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     protected function content(): Attribute
     {
@@ -96,12 +101,12 @@ class InlineComment extends BaseModel
     }
 
     /**
-     * @return Attribute
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function styleCriteria(): Attribute
     {
         return Attribute::make(
-            get: function(mixed $value, array $attributes) {
+            get: function (mixed $value, array $attributes) {
                 return $this->trashed() ? [] : json_decode($attributes['style_criteria']);
             }
         );

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -7,11 +7,13 @@ use App\Http\Traits\CreatedUpdatedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class InlineComment extends BaseModel
 {
     use HasFactory;
     use CreatedUpdatedBy;
+    use SoftDeletes;
 
     protected $casts = [
         'style_criteria' => 'json',

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Http\Traits\CreatedUpdatedBy;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -55,7 +56,7 @@ class InlineComment extends BaseModel
     }
 
     /**
-     * The creator of the inline comment
+      * The creator of the inline comment
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -72,5 +73,37 @@ class InlineComment extends BaseModel
     public function updatedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    /**
+     * @return Attribute
+     */
+    protected function username(): Attribute
+    {
+        return Attribute::make(
+            get: fn (int $value) => $this->trashed() ? "" : $value,
+        );
+    }
+
+    /**
+     * @return Attribute
+     */
+    protected function content(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => $this->trashed() ? 'This comment has been deleted' : $value,
+        );
+    }
+
+    /**
+     * @return Attribute
+     */
+    public function styleCriteria(): Attribute
+    {
+        return Attribute::make(
+            get: function(mixed $value, array $attributes) {
+                return $this->trashed() ? [] : json_decode($attributes['style_criteria']);
+            }
+        );
     }
 }

--- a/backend/app/Models/OverallComment.php
+++ b/backend/app/Models/OverallComment.php
@@ -7,11 +7,13 @@ use App\Http\Traits\CreatedUpdatedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class OverallComment extends BaseModel
 {
     use HasFactory;
     use CreatedUpdatedBy;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -242,7 +242,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update the inline comments of a submission
+     * Update or delete the inline comments of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -251,8 +251,8 @@ class SubmissionPolicy
      */
     public function updateInlineComments(User $user, Submission $_, $args)
     {
-        if (isset($args['inlineComments']['update'])) {
-            $comment_id = $args['inlineComments']['update'][0]['id'];
+        if (isset($args['inlineComments']['update']) || isset($args['inlineComments']['delete'])) {
+            $comment_id = $args['inlineComments']['update'][0]['id'] ?: $args['inlineComments']['update']['id'];
             $inline_comment = InlineComment::where('id', $comment_id)->firstOrFail();
             if ($inline_comment->created_by === $user->id) {
                 return true;
@@ -265,7 +265,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update the overall comments of a submission
+     * Update or delete the overall comments of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -274,8 +274,8 @@ class SubmissionPolicy
      */
     public function updateOverallComments(User $user, Submission $_, $args)
     {
-        if (isset($args['overallComments']['update'])) {
-            $comment_id = $args['overallComments']['update'][0]['id'];
+        if (isset($args['overallComments']['update']) || isset($args['overallComments']['delete'])) {
+            $comment_id = $args['overallComments']['update'][0]['id'] ?: $args['overallComments']['delete']['id'];
             $overall_comment = OverallComment::where('id', $comment_id)->firstOrFail();
             if ($overall_comment->created_by === $user->id) {
                 return true;

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -274,15 +274,13 @@ class SubmissionPolicy
      */
     public function deleteInlineComment(User $user, Submission $_, array $args)
     {
-        if (isset($args['deleteInlineComment'])) {
-            $comment_id = $args['deleteInlineComment']['comment_id'];
-            $inline_comment = InlineComment::findOrFail($comment_id);
+        if (isset($args['comment_id'])) {
+            $inline_comment = InlineComment::findOrFail($args['comment_id']);
             if ($inline_comment->created_by === $user->id) {
                 return true;
             }
-            return Response::deny('UNAUTHORIZED');
         }
-        return true;
+        return Response::deny('UNAUTHORIZED');
     }
 
     /**

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -252,7 +252,7 @@ class SubmissionPolicy
     public function updateInlineComments(User $user, Submission $_, $args)
     {
         if (isset($args['inlineComments']['update']) || isset($args['inlineComments']['delete'])) {
-            $comment_id = $args['inlineComments']['update'][0]['id'] ?: $args['inlineComments']['update']['id'];
+            $comment_id = $args['inlineComments']['update'][0]['id'] ?: $args['inlineComments']['delete']['id'];
             $inline_comment = InlineComment::where('id', $comment_id)->firstOrFail();
             if ($inline_comment->created_by === $user->id) {
                 return true;

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -242,7 +242,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update the inline comment of a submission
+     * Update an inline comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -265,7 +265,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Delete the inline comment of a submission
+     * Delete an inline comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -285,7 +285,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update or delete the overall comments of a submission
+     * Update an overall comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -308,7 +308,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Delete the overall comment of a submission
+     * Delete an overall comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -242,7 +242,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update or delete the inline comments of a submission
+     * Update the inline comments of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -251,8 +251,8 @@ class SubmissionPolicy
      */
     public function updateInlineComments(User $user, Submission $_, $args)
     {
-        if (isset($args['inlineComments']['update']) || isset($args['inlineComments']['delete'])) {
-            $comment_id = $args['inlineComments']['update'][0]['id'] ?: $args['inlineComments']['delete']['id'];
+        if (isset($args['inlineComments']['update'])) {
+            $comment_id = $args['inlineComments']['update'][0]['id'];
             $inline_comment = InlineComment::where('id', $comment_id)->firstOrFail();
             if ($inline_comment->created_by === $user->id) {
                 return true;
@@ -261,6 +261,27 @@ class SubmissionPolicy
             return Response::deny('UNAUTHORIZED');
         }
 
+        return true;
+    }
+
+    /**
+     * Delete the inline comments of a submission
+     *
+     * @param \App\Models\User $user
+     * @param \App\Models\Submission $_
+     * @param  array {submission_id: string, comment_id:string}  $args
+     * @return bool|\Illuminate\Auth\Access\Response
+     */
+    public function deleteInlineComment(User $user, Submission $_, array $args)
+    {
+        if (isset($args['deleteInlineComment'])) {
+            $comment_id = $args['deleteInlineComment']['comment_id'];
+            $inline_comment = InlineComment::findOrFail($comment_id);
+            if ($inline_comment->created_by === $user->id) {
+                return true;
+            }
+            return Response::deny('UNAUTHORIZED');
+        }
         return true;
     }
 

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -242,7 +242,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Update the inline comments of a submission
+     * Update the inline comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -265,7 +265,7 @@ class SubmissionPolicy
     }
 
     /**
-     * Delete the inline comments of a submission
+     * Delete the inline comment of a submission
      *
      * @param \App\Models\User $user
      * @param \App\Models\Submission $_
@@ -293,8 +293,8 @@ class SubmissionPolicy
      */
     public function updateOverallComments(User $user, Submission $_, $args)
     {
-        if (isset($args['overallComments']['update']) || isset($args['overallComments']['delete'])) {
-            $comment_id = $args['overallComments']['update'][0]['id'] ?: $args['overallComments']['delete']['id'];
+        if (isset($args['overallComments']['update'])) {
+            $comment_id = $args['overallComments']['update'][0]['id'];
             $overall_comment = OverallComment::where('id', $comment_id)->firstOrFail();
             if ($overall_comment->created_by === $user->id) {
                 return true;
@@ -304,5 +304,24 @@ class SubmissionPolicy
         }
 
         return true;
+    }
+
+    /**
+     * Delete the overall comment of a submission
+     *
+     * @param \App\Models\User $user
+     * @param \App\Models\Submission $_
+     * @param  array {submission_id: string, comment_id:string}  $args
+     * @return bool|\Illuminate\Auth\Access\Response
+     */
+    public function deleteOverallComment(User $user, Submission $_, array $args)
+    {
+        if (isset($args['comment_id'])) {
+            $overall_comment = OverallComment::findOrFail($args['comment_id']);
+            if ($overall_comment->created_by === $user->id) {
+                return true;
+            }
+        }
+        return Response::deny('UNAUTHORIZED');
     }
 }

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -280,6 +280,7 @@ class SubmissionPolicy
                 return true;
             }
         }
+
         return Response::deny('UNAUTHORIZED');
     }
 
@@ -322,6 +323,7 @@ class SubmissionPolicy
                 return true;
             }
         }
+
         return Response::deny('UNAUTHORIZED');
     }
 }

--- a/backend/app/Rules/InlineCommentIdValidity.php
+++ b/backend/app/Rules/InlineCommentIdValidity.php
@@ -90,7 +90,7 @@ class InlineCommentIdValidity implements Rule, DataAwareRule
                 !is_null($data['reply_to_id'])
             ) {
                 try {
-                    $this->parent = InlineComment::where('id', $data['parent_id'])->firstOrFail();
+                    $this->parent = InlineComment::withTrashed()->where('id', $data['parent_id'])->firstOrFail();
                 } catch (Exception $error) {
                     $this->error_message = $error->getMessage();
 

--- a/backend/app/Rules/OverallCommentIdValidity.php
+++ b/backend/app/Rules/OverallCommentIdValidity.php
@@ -90,7 +90,7 @@ class OverallCommentIdValidity implements Rule, DataAwareRule
                 !is_null($data['reply_to_id'])
             ) {
                 try {
-                    $this->parent = OverallComment::where('id', $data['parent_id'])->firstOrFail();
+                    $this->parent = OverallComment::withTrashed()->where('id', $data['parent_id'])->firstOrFail();
                 } catch (Exception $error) {
                     $this->error_message = $error->getMessage();
 

--- a/backend/database/migrations/2023_12_18_213126_add_softdeletes_to_inline_comments.php
+++ b/backend/database/migrations/2023_12_18_213126_add_softdeletes_to_inline_comments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('inline_comments', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('inline_comments', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/backend/database/migrations/2023_12_18_213319_add_softdeletes_to_overall_comments.php
+++ b/backend/database/migrations/2023_12_18_213319_add_softdeletes_to_overall_comments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('overall_comments', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('overall_comments', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/backend/database/seeders/InlineCommentSeeder.php
+++ b/backend/database/seeders/InlineCommentSeeder.php
@@ -72,13 +72,13 @@ class InlineCommentSeeder extends Seeder
             // Seed inline comment replies
             $comments = collect([$parent]);
             for ($i = 0; $i < $opts['replies']; $i++) {
-                $comments->push($this->createCommentReply(true, $userIds->random(), $parent, $comments->random()));
+                $comments->push($this->createCommentReply($submissionId, $userIds->random(), $parent, $comments->random()));
             }
         }
     }
 
     /**
-     * @param bool $submissionId
+     * @param int $submissionId
      * @param \App\Models\User $userId
      * @param \App\Models\InlineComment|\App\Models\OverallComment $parent
      * @param \App\Models\InlineComment|\App\Models\OverallComment $reply_to

--- a/backend/database/seeders/InlineCommentSeeder.php
+++ b/backend/database/seeders/InlineCommentSeeder.php
@@ -72,7 +72,8 @@ class InlineCommentSeeder extends Seeder
             // Seed inline comment replies
             $comments = collect([$parent]);
             for ($i = 0; $i < $opts['replies']; $i++) {
-                $comments->push($this->createCommentReply($submissionId, $userIds->random(), $parent, $comments->random()));
+                $reply = $this->createCommentReply($submissionId, $userIds->random(), $parent, $comments->random());
+                $comments->push($reply);
             }
         }
     }

--- a/backend/database/seeders/OverallCommentSeeder.php
+++ b/backend/database/seeders/OverallCommentSeeder.php
@@ -38,7 +38,9 @@ class OverallCommentSeeder extends Seeder
     {
         $userIds = User::all()->pluck('id');
         if ($userId === null) {
-            $userId = $userIds->except(1)->random(); // Ensure that the comment is not created by the application admin
+            // Ensure that the comment is not created by the application
+            // admin to prevent the admin replying to their own comment
+            $userId = $userIds->except(1)->random();
         }
 
         $parent = OverallComment::factory()->create([
@@ -52,7 +54,7 @@ class OverallCommentSeeder extends Seeder
             $comments = collect([$parent]);
 
             for ($i = 0; $i < $replies; $i++) {
-                $comments->push($this->createCommentReply(false, $userIds->random(), $parent, $comments->random()));
+                $comments->push($this->createCommentReply(false, $userIds->except(1)->random(), $parent, $comments->random()));
             }
         }
     }

--- a/backend/database/seeders/OverallCommentSeeder.php
+++ b/backend/database/seeders/OverallCommentSeeder.php
@@ -23,6 +23,7 @@ class OverallCommentSeeder extends Seeder
         $this->create(100);
         $this->create(100, 1);
         $this->create(100, 8);
+        $this->create(100, 1, 1);
     }
 
     /**
@@ -30,12 +31,15 @@ class OverallCommentSeeder extends Seeder
      *
      * @param int $submissionId
      * @param int $replies
+     * @param int $userId
      * @return void
      */
-    protected function create($submissionId, $replies = 0)
+    protected function create($submissionId, $replies = 0, $userId = null)
     {
         $userIds = User::all()->pluck('id');
-        $userId = $userIds->except(1)->random(); // Ensure that the comment is not created by the application admin
+        if ($userId === null) {
+            $userId = $userIds->except(1)->random(); // Ensure that the comment is not created by the application admin
+        }
 
         $parent = OverallComment::factory()->create([
             'submission_id' => $submissionId,

--- a/backend/database/seeders/OverallCommentSeeder.php
+++ b/backend/database/seeders/OverallCommentSeeder.php
@@ -54,7 +54,8 @@ class OverallCommentSeeder extends Seeder
             $comments = collect([$parent]);
 
             for ($i = 0; $i < $replies; $i++) {
-                $comments->push($this->createCommentReply(false, $userIds->except(1)->random(), $parent, $comments->random()));
+                $reply = $this->createCommentReply(false, $userIds->except(1)->random(), $parent, $comments->random());
+                $comments->push($reply);
             }
         }
     }

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -87,7 +87,7 @@ input InlineCommentHasManyInput {
             ]
         )
     update: [UpdateInlineCommentInput!]
-    delete: ID!
+    delete: ID
 }
 
 input CreateInlineCommentInput {
@@ -116,7 +116,7 @@ input OverallCommentHasManyInput {
             ]
         )
     update: [UpdateOverallCommentInput!]
-    delete: ID!
+    delete: ID
 }
 
 input CreateOverallCommentInput {

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -87,7 +87,6 @@ input InlineCommentHasManyInput {
             ]
         )
     update: [UpdateInlineCommentInput!]
-    delete: ID
 }
 
 input CreateInlineCommentInput {
@@ -116,7 +115,6 @@ input OverallCommentHasManyInput {
             ]
         )
     update: [UpdateOverallCommentInput!]
-    delete: ID
 }
 
 input CreateOverallCommentInput {

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -54,6 +54,7 @@ type OverallComment implements Comment {
     created_at: DateTimeUtc!
     updated_by: User! @belongsTo(relation: "updatedBy")
     updated_at: DateTimeUtc!
+    deleted_at: DateTimeUtc
     replies: [OverallCommentReply!] @hasMany
 }
 
@@ -67,6 +68,7 @@ type OverallCommentReply implements Comment {
     updated_by: User! @belongsTo(relation: "updatedBy")
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
+    deleted_at: DateTimeUtc
     parent_id: ID!
     reply_to_id: ID!
 }
@@ -135,4 +137,5 @@ interface Comment {
     updated_by: User!
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
+    deleted_at: DateTimeUtc
 }

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -14,7 +14,7 @@ type InlineComment implements Comment {
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
     deleted_at: DateTimeUtc
-    replies: [InlineCommentReply!] @hasMany
+    replies: [InlineCommentReply!] @hasMany @softDeletes
     style_criteria: [InlineCommentStyleCriteria!]
     from: Int
     to: Int
@@ -55,7 +55,7 @@ type OverallComment implements Comment {
     updated_by: User! @belongsTo(relation: "updatedBy")
     updated_at: DateTimeUtc!
     deleted_at: DateTimeUtc
-    replies: [OverallCommentReply!] @hasMany
+    replies: [OverallCommentReply!] @hasMany @softDeletes
 }
 
 """

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -85,6 +85,7 @@ input InlineCommentHasManyInput {
             ]
         )
     update: [UpdateInlineCommentInput!]
+    delete: ID!
 }
 
 input CreateInlineCommentInput {
@@ -113,6 +114,7 @@ input OverallCommentHasManyInput {
             ]
         )
     update: [UpdateOverallCommentInput!]
+    delete: ID!
 }
 
 input CreateOverallCommentInput {

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -1,6 +1,6 @@
 extend type Submission {
-    inline_comments: [InlineComment!]! @hasMany(relation: "inlineComments")
-    overall_comments: [OverallComment!]! @hasMany(relation: "overallComments")
+    inline_comments: [InlineComment!]! @hasMany(relation: "inlineComments") @softDeletes
+    overall_comments: [OverallComment!]! @hasMany(relation: "overallComments") @softDeletes
 }
 
 """
@@ -13,6 +13,7 @@ type InlineComment implements Comment {
     updated_by: User! @belongsTo(relation: "updatedBy")
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
+    deleted_at: DateTimeUtc
     replies: [InlineCommentReply!] @hasMany
     style_criteria: [InlineCommentStyleCriteria!]
     from: Int
@@ -38,6 +39,7 @@ type InlineCommentReply implements Comment {
     updated_by: User! @belongsTo(relation: "updatedBy")
     created_at: DateTimeUtc!
     updated_at: DateTimeUtc!
+    deleted_at: DateTimeUtc
     parent_id: ID!
     reply_to_id: ID!
 }

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -5,7 +5,10 @@ extend type Query {
     submission(id: ID @eq): Submission @find @can(ability: "view", find: "id")
 
     "Return all submissions"
-    submissions: [Submission!] @can(ability: "viewAll", query: true) @paginate(defaultCount: 100) @orderBy(column: "created_at", direction: DESC)
+    submissions: [Submission!]
+        @can(ability: "viewAll", query: true)
+        @paginate(defaultCount: 100)
+        @orderBy(column: "created_at", direction: DESC)
 }
 
 extend type Mutation {
@@ -33,12 +36,13 @@ extend type Mutation {
         )
 
     "Delete an inline comment of a submission"
-    deleteInlineComment(
-        input: DeleteInlineCommentInput! @spread
-    ): Submission! @canFind(ability: "deleteInlineComment", find: "submission_id")
-        @field(
-            resolver: "App\\GraphQL\\Mutations\\DeleteInlineComment@delete"
+    deleteInlineComment(input: DeleteInlineCommentInput! @spread): Submission!
+        @argPolicy(
+            find: "submission_id"
+            apply: ["comment_id:deleteInlineComment"]
+            injectArgs: true
         )
+        @field(resolver: "App\\GraphQL\\Mutations\\DeleteInlineComment@delete")
 
     "Update the content of a submission"
     updateSubmissionContent(
@@ -48,7 +52,8 @@ extend type Mutation {
     "Update the content of a submission with a file upload"
     updateSubmissionContentWithFile(
         input: CreateSubmissionFileInput! @spread
-    ): Submission! @can(ability: "update", find: "submission_id")
+    ): Submission!
+        @can(ability: "update", find: "submission_id")
         @field(
             resolver: "App\\GraphQL\\Mutations\\UpdateSubmissionContentWithFile@update"
         )
@@ -99,9 +104,7 @@ extend type Mutation {
     """
     Resend an email notification inviting a staged reviewer to accept the assignment
     """
-    reinviteReviewer(
-        input: reinviteSubmissionUserInput @spread
-    ): Submission
+    reinviteReviewer(input: reinviteSubmissionUserInput @spread): Submission
         @can(ability: "invite", find: "submission_id")
         @field(
             resolver: "App\\GraphQL\\Mutations\\ReinviteSubmissionUser@reinviteReviewer"
@@ -126,7 +129,8 @@ input inviteSubmissionUserInput
     message: String
 }
 
-input reinviteSubmissionUserInput @validator(class: "SubmissionReinvitationValidator") {
+input reinviteSubmissionUserInput
+    @validator(class: "SubmissionReinvitationValidator") {
     submission_id: ID!
     email: String!
     message: String
@@ -202,7 +206,8 @@ input DeleteInlineCommentInput {
 """
 Input type for creating a new submission via the createSubmissionDraft mutation
 """
-input CreateSubmissionDraftInput @validator(class: "SubmissionDraftInputValidator") {
+input CreateSubmissionDraftInput
+    @validator(class: "SubmissionDraftInputValidator") {
     title: String! @trim
     publication_id: ID!
     submitters: CreateSubmissionUserInput

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -32,6 +32,14 @@ extend type Mutation {
             injectArgs: true
         )
 
+    "Delete an inline comment of a submission"
+    deleteInlineComment(
+        input: DeleteInlineCommentInput! @spread
+    ): Submission! @canFind(ability: "deleteInlineComment", find: "submission_id")
+        @field(
+            resolver: "App\\GraphQL\\Mutations\\DeleteInlineComment@delete"
+        )
+
     "Update the content of a submission"
     updateSubmissionContent(
         input: UpdateSubmissionContent! @spread
@@ -184,6 +192,11 @@ enum SubmissionStatus {
     REVISION_REQUESTED @enum(value: 10)
     ARCHIVED @enum(value: 11)
     DELETED @enum(value: 12)
+}
+
+input DeleteInlineCommentInput {
+    submission_id: ID!
+    comment_id: ID!
 }
 
 """

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -38,8 +38,8 @@ extend type Mutation {
     "Delete an inline comment of a submission"
     deleteInlineComment(input: DeleteInlineCommentInput! @spread): Submission!
         @argPolicy(
-            find: "submission_id"
             apply: ["comment_id:deleteInlineComment"]
+            find: "submission_id"
             injectArgs: true
         )
         @field(resolver: "App\\GraphQL\\Mutations\\DeleteInlineComment@delete")

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -36,13 +36,22 @@ extend type Mutation {
         )
 
     "Delete an inline comment of a submission"
-    deleteInlineComment(input: DeleteInlineCommentInput! @spread): Submission!
+    deleteInlineComment(input: DeleteCommentInput! @spread): Submission!
         @argPolicy(
             apply: ["comment_id:deleteInlineComment"]
             find: "submission_id"
             injectArgs: true
         )
         @field(resolver: "App\\GraphQL\\Mutations\\DeleteInlineComment@delete")
+
+    "Delete an overall comment of a submission"
+    deleteOverallComment(input: DeleteCommentInput! @spread): Submission!
+        @argPolicy(
+            apply: ["comment_id:deleteOverallComment"]
+            find: "submission_id"
+            injectArgs: true
+        )
+        @field(resolver: "App\\GraphQL\\Mutations\\DeleteOverallComment@delete")
 
     "Update the content of a submission"
     updateSubmissionContent(
@@ -198,7 +207,7 @@ enum SubmissionStatus {
     DELETED @enum(value: 12)
 }
 
-input DeleteInlineCommentInput {
+input DeleteCommentInput {
     submission_id: ID!
     comment_id: ID!
 }

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -8,12 +8,15 @@ use App\Models\OverallComment;
 use App\Models\StyleCriteria;
 use App\Models\Submission;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Str;
 use Tests\ApiTestCase;
 
 class SubmissionCommentTest extends ApiTestCase
 {
+    use WithFaker;
     use RefreshDatabase;
 
     /**
@@ -48,7 +51,7 @@ class SubmissionCommentTest extends ApiTestCase
 
     /**
      * @param int $count
-     * @param User|null $user
+     * @param User|null $user (optional)
      * @return Submission
      */
     private function createSubmissionWithInlineComment($count = 1, $user = null)
@@ -71,11 +74,14 @@ class SubmissionCommentTest extends ApiTestCase
 
     /**
      * @param int $count
+     * @param User|null $user (optional)
      * @return Submission
      */
-    private function createSubmissionWithOverallComment($count = 1)
+    private function createSubmissionWithOverallComment($count = 1, $user = null)
     {
-        $user = User::factory()->create();
+        if ($user === null) {
+            $user = User::factory()->create();
+        }
         $submission = $this->createSubmission();
         OverallComment::factory()->count($count)->create([
             'submission_id' => $submission->id,
@@ -773,6 +779,9 @@ class SubmissionCommentTest extends ApiTestCase
         ->assertGraphQLErrorMessage('UNAUTHORIZED');
     }
 
+    /**
+     * @return void
+     */
     public function testUsersCanDeleteTheirOwnInlineComments()
     {
         $admin = $this->beAppAdmin();
@@ -821,4 +830,259 @@ class SubmissionCommentTest extends ApiTestCase
         $response->assertJsonPath('data', $expected_data);
     }
 
+    /**
+     * @return void
+     */
+    public function testUsersCanDeleteTheirOwnOverallComments()
+    {
+        $admin = $this->beAppAdmin();
+        $submission = $this->createSubmissionWithOverallComment(1, $admin);
+        $count_before_deletion = $submission->overallComments()->count();
+        $overall_comment = $submission->overallComments->first();
+        $response = $this->graphQL(
+            'mutation DeleteOverallComment ($submission_id: ID! $comment_id: ID!) {
+                deleteOverallComment(
+                    input: {
+                        submission_id: $submission_id,
+                        comment_id: $comment_id
+                    }
+                ) {
+                    id
+                    overall_comments(trashed: WITH) {
+                        id
+                        content
+                    }
+                }
+            }',
+            [
+                'submission_id' => $submission->id,
+                'comment_id' => $overall_comment->id,
+            ]
+        );
+        $expected_data = [
+            'deleteOverallComment' => [
+                'id' => (string)$submission->id,
+                'overall_comments' => [
+                    '0' => [
+                        'id' => (string)$overall_comment->id,
+                        'content' => 'This comment has been deleted',
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSoftDeleted($overall_comment);
+        $count_after_deletion = $submission->overallComments()->count();
+        $this->assertEquals($count_before_deletion, 1);
+        $this->assertEquals($count_after_deletion, 0);
+        $response->assertJsonPath('data', $expected_data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUsersCannotDeleteTheInlineCommentsOfOthers(): void
+    {
+        $this->beAppAdmin();
+        $submission = $this->createSubmissionWithInlineComment();
+        $inline_comment = $submission->inlineComments->first();
+        $this->graphQL(
+            'mutation DeleteInlineComment ($submission_id: ID! $comment_id: ID!) {
+                deleteInlineComment(
+                    input: {
+                        submission_id: $submission_id,
+                        comment_id: $comment_id
+                    }
+                ) {
+                    id
+                    inline_comments(trashed: WITH) {
+                        id
+                        content
+                        style_criteria {
+                            name
+                        }
+                    }
+                }
+            }',
+            [
+                'submission_id' => $submission->id,
+                'comment_id' => $inline_comment->id,
+            ]
+        )
+        ->assertGraphQLErrorMessage('UNAUTHORIZED');
+    }
+
+    /**
+     * @return void
+     */
+    public function testUsersCannotDeleteTheOverallCommentsOfOthers(): void
+    {
+        $this->beAppAdmin();
+        $submission = $this->createSubmissionWithOverallComment();
+        $overall_comment = $submission->overallComments->first();
+        $this->graphQL(
+            'mutation DeleteOverallComment ($submission_id: ID! $comment_id: ID!) {
+                deleteOverallComment(
+                    input: {
+                        submission_id: $submission_id,
+                        comment_id: $comment_id
+                    }
+                ) {
+                    id
+                    overall_comments(trashed: WITH) {
+                        id
+                        content
+                    }
+                }
+            }',
+            [
+                'submission_id' => $submission->id,
+                'comment_id' => $overall_comment->id,
+            ]
+        )
+        ->assertGraphQLErrorMessage('UNAUTHORIZED');
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteInlineCommentReply()
+    {
+        $admin = $this->beAppAdmin();
+        $submission = $this->createSubmissionWithInlineComment();
+        $inline_comment = $submission->inlineComments()->first();
+        $time = Carbon::parse($inline_comment->created_at);
+        $datetime = $this->faker->dateTimeBetween($time, Carbon::now());
+        $reply = InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'parent_id' => $inline_comment->id,
+            'reply_to_id' => $inline_comment->id,
+            'created_at' => $datetime,
+            'updated_at' => $datetime,
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+        $count_before_deletion = $submission->inlineComments()->count();
+        $response = $this->graphQL(
+            'mutation DeleteInlineComment ($submission_id: ID! $comment_id: ID!) {
+                deleteInlineComment(
+                    input: {
+                        submission_id: $submission_id,
+                        comment_id: $comment_id
+                    }
+                ) {
+                    id
+                    inline_comments {
+                        id
+                        content
+                        style_criteria {
+                            name
+                        }
+                        replies(trashed: WITH) {
+                            id
+                            content
+                        }
+                    }
+                }
+            }',
+            [
+                'submission_id' => $submission->id,
+                'comment_id' => $reply->id,
+            ]
+        );
+        $expected_data = [
+            'deleteInlineComment' => [
+                'id' => (string)$submission->id,
+                'inline_comments' => [
+                    '0' => [
+                        'id' => (string)$inline_comment->id,
+                        'content' => 'This is some content for an inline comment created by PHPUnit.',
+                        'style_criteria' => [
+                            '0' => [
+                                'name' => 'PHPUnit Criteria',
+                            ],
+                        ],
+                        'replies' => [
+                            '0' => [
+                                'id' => (string)$reply->id,
+                                'content' => 'This comment has been deleted',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSoftDeleted($reply);
+        $count_after_deletion = $submission->inlineComments()->count();
+        $this->assertEquals($count_before_deletion, 1);
+        $this->assertEquals($count_after_deletion, 1);
+        $response->assertJsonPath('data', $expected_data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteOverallCommentReply()
+    {
+        $admin = $this->beAppAdmin();
+        $submission = $this->createSubmissionWithOverallComment();
+        $overall_comment = $submission->overallComments()->first();
+        $time = Carbon::parse($overall_comment->created_at);
+        $datetime = $this->faker->dateTimeBetween($time, Carbon::now());
+        $reply = OverallComment::factory()->create([
+            'submission_id' => $submission->id,
+            'parent_id' => $overall_comment->id,
+            'reply_to_id' => $overall_comment->id,
+            'created_at' => $datetime,
+            'updated_at' => $datetime,
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+        $count_before_deletion = $submission->overallComments()->count();
+        $response = $this->graphQL(
+            'mutation DeleteOverallComment ($submission_id: ID! $comment_id: ID!) {
+                deleteOverallComment(
+                    input: {
+                        submission_id: $submission_id,
+                        comment_id: $comment_id
+                    }
+                ) {
+                    id
+                    overall_comments {
+                        id
+                        content
+                        replies(trashed: WITH) {
+                            id
+                            content
+                        }
+                    }
+                }
+            }',
+            [
+                'submission_id' => $submission->id,
+                'comment_id' => $reply->id,
+            ]
+        );
+        $expected_data = [
+            'deleteOverallComment' => [
+                'id' => (string)$submission->id,
+                'overall_comments' => [
+                    '0' => [
+                        'id' => (string)$overall_comment->id,
+                        'content' => 'This is some content for an overall comment created by PHPUnit.',
+                        'replies' => [
+                            '0' => [
+                                'id' => (string)$reply->id,
+                                'content' => 'This comment has been deleted',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSoftDeleted($reply);
+        $count_after_deletion = $submission->overallComments()->count();
+        $this->assertEquals($count_before_deletion, 1);
+        $this->assertEquals($count_after_deletion, 1);
+        $response->assertJsonPath('data', $expected_data);
+    }
 }

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -819,9 +819,9 @@ class SubmissionCommentTest extends ApiTestCase
                         'id' => (string)$inline_comment->id,
                         'content' => 'This comment has been deleted',
                         'style_criteria' => [],
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
         $this->assertSoftDeleted($inline_comment);
         $count_after_deletion = $submission->inlineComments()->count();
@@ -866,9 +866,9 @@ class SubmissionCommentTest extends ApiTestCase
                     '0' => [
                         'id' => (string)$overall_comment->id,
                         'content' => 'This comment has been deleted',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
         $this->assertSoftDeleted($overall_comment);
         $count_after_deletion = $submission->overallComments()->count();
@@ -1005,11 +1005,11 @@ class SubmissionCommentTest extends ApiTestCase
                             '0' => [
                                 'id' => (string)$reply->id,
                                 'content' => 'This comment has been deleted',
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
         $this->assertSoftDeleted($reply);
         $count_after_deletion = $submission->inlineComments()->count();
@@ -1073,11 +1073,11 @@ class SubmissionCommentTest extends ApiTestCase
                             '0' => [
                                 'id' => (string)$reply->id,
                                 'content' => 'This comment has been deleted',
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
         $this->assertSoftDeleted($reply);
         $count_after_deletion = $submission->overallComments()->count();

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -27,9 +27,9 @@
             }}</q-item-section>
           </q-item>
           <q-item clickable>
-            <q-item-section
-              >{{ $t("submissions.comment.actions.delete") }}
-            </q-item-section>
+            <q-item-section>{{
+              $t("submissions.comment.actions.delete")
+            }}</q-item-section>
           </q-item>
         </q-list>
       </q-menu>

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -27,9 +27,9 @@
             }}</q-item-section>
           </q-item>
           <q-item clickable>
-            <q-item-section>{{
-              $t("submissions.comment.actions.share")
-            }}</q-item-section>
+            <q-item-section
+              >{{ $t("submissions.comment.actions.delete") }}
+            </q-item-section>
           </q-item>
         </q-list>
       </q-menu>

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -45,11 +45,11 @@
 <script setup>
 import { inject, computed } from "vue"
 import { useCurrentUser } from "src/use/user"
+import ConfirmCommentDeletion from "../dialogs/ConfirmCommentDeletion.vue";
+import { useQuasar } from "quasar"
+const { dialog } = useQuasar()
 
 const { currentUser } = useCurrentUser()
-
-// import { useQuasar } from "quasar"
-// const { dialog } = useQuasar()
 
 const comment = inject("comment")
 
@@ -61,12 +61,11 @@ const createdByCurrentUser = computed(() => {
 
 async function deleteHandler() {
   emit("deleteComment")
-  // dialog({
-  //   component: ConfirmStatusChangeDialog,
-  //   componentProps: {
-  //     action: action,
-  //     submissionId: props.submission.id,
-  //   },
-  // })
+  dialog({
+    component: ConfirmCommentDeletion,
+    componentProps: {
+      comment: comment.content,
+    },
+  })
 }
 </script>

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -26,7 +26,12 @@
               $t("submissions.comment.actions.modify")
             }}</q-item-section>
           </q-item>
-          <q-item v-if="createdByCurrentUser" data-cy="deleteComment" clickable>
+          <q-item
+            v-if="createdByCurrentUser"
+            data-cy="deleteComment"
+            clickable
+            @click="deleteHandler()"
+          >
             <q-item-section>{{
               $t("submissions.comment.actions.delete")
             }}</q-item-section>
@@ -43,11 +48,25 @@ import { useCurrentUser } from "src/use/user"
 
 const { currentUser } = useCurrentUser()
 
+// import { useQuasar } from "quasar"
+// const { dialog } = useQuasar()
+
 const comment = inject("comment")
 
-defineEmits(["quoteReplyTo", "modifyComment"])
+const emit = defineEmits(["quoteReplyTo", "modifyComment", "deleteComment"])
 
 const createdByCurrentUser = computed(() => {
   return currentUser.value.id == comment.created_by.id
 })
+
+async function deleteHandler() {
+  emit("deleteComment")
+  // dialog({
+  //   component: ConfirmStatusChangeDialog,
+  //   componentProps: {
+  //     action: action,
+  //     submissionId: props.submission.id,
+  //   },
+  // })
+}
 </script>

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -52,6 +52,7 @@ const { dialog } = useQuasar()
 const { currentUser } = useCurrentUser()
 
 const comment = inject("comment")
+const submission = inject("submission")
 
 const emit = defineEmits(["quoteReplyTo", "modifyComment", "deleteComment"])
 
@@ -64,7 +65,8 @@ async function deleteHandler() {
   dialog({
     component: ConfirmCommentDeletion,
     componentProps: {
-      comment: comment.content,
+      comment: comment,
+      submissionId: submission.value.id,
     },
   })
 }

--- a/client/src/components/atoms/CommentActions.vue
+++ b/client/src/components/atoms/CommentActions.vue
@@ -17,7 +17,7 @@
             }}</q-item-section></q-item
           >
           <q-item
-            v-if="checkCommentCreatedBy == false"
+            v-if="createdByCurrentUser"
             data-cy="modifyComment"
             clickable
             @click="$emit('modifyComment')"
@@ -26,7 +26,7 @@
               $t("submissions.comment.actions.modify")
             }}</q-item-section>
           </q-item>
-          <q-item clickable>
+          <q-item v-if="createdByCurrentUser" data-cy="deleteComment" clickable>
             <q-item-section>{{
               $t("submissions.comment.actions.delete")
             }}</q-item-section>
@@ -47,13 +47,7 @@ const comment = inject("comment")
 
 defineEmits(["quoteReplyTo", "modifyComment"])
 
-const checkCommentCreatedBy = computed(() => {
-  const userToCheck = currentUser.value.id
-  const commentCreatedBy = comment.created_by.id
-  if (userToCheck == commentCreatedBy) {
-    return false
-  } else {
-    return true
-  }
+const createdByCurrentUser = computed(() => {
+  return currentUser.value.id == comment.created_by.id
 })
 </script>

--- a/client/src/components/atoms/CommentHeader.vue
+++ b/client/src/components/atoms/CommentHeader.vue
@@ -64,6 +64,7 @@
       <comment-actions
         @quote-reply-to="$emit('quoteReplyTo')"
         @modify-comment="$emit('modifyComment')"
+        @delete-comment="$emit('deleteComment')"
       />
     </div>
   </q-card-section>
@@ -88,7 +89,7 @@ const props = defineProps({
     default: null,
   },
 })
-defineEmits(["quoteReplyTo", "modifyComment"])
+defineEmits(["quoteReplyTo", "modifyComment", "deleteComment"])
 const style = computed(() => {
   const style = {}
   if (props.bgColor) {

--- a/client/src/components/atoms/CommentHeader.vue
+++ b/client/src/components/atoms/CommentHeader.vue
@@ -1,11 +1,20 @@
 <template>
-  <q-card-section v-if="comment.deleted_at != null">
-    <div class="row items-center">
-    {{
-      $t("submissions.comment.dateLabelDeleted", {
-        date: relativeDeletedTime,
-      })
-    }}
+  <q-card-section
+    v-if="comment.deleted_at != null"
+    class="q-py-sm"
+    :style="style"
+  >
+    <div class="row items-center justify-end">
+      <span>
+        {{
+          $t("submissions.comment.dateLabelDeleted", {
+            date: relativeDeletedTime,
+          })
+        }}
+        <q-tooltip>
+          {{ deletedDate.toFormat("LLL dd yyyy hh:mm a") }}
+        </q-tooltip>
+      </span>
     </div>
   </q-card-section>
   <q-card-section v-else class="q-py-xs" :style="style">

--- a/client/src/components/atoms/CommentHeader.vue
+++ b/client/src/components/atoms/CommentHeader.vue
@@ -1,5 +1,14 @@
 <template>
-  <q-card-section class="q-py-xs" :style="style">
+  <q-card-section v-if="comment.deleted_at != null">
+    <div class="row items-center">
+    {{
+      $t("submissions.comment.dateLabelDeleted", {
+        date: relativeDeletedTime,
+      })
+    }}
+    </div>
+  </q-card-section>
+  <q-card-section v-else class="q-py-xs" :style="style">
     <div class="row items-center">
       <avatar-image
         :user="comment.created_by"
@@ -98,6 +107,18 @@ const updatedDate = computed(() => {
 const relativeUpdatedTime = computed(() => {
   return updatedDate.value
     ? timeAgo.format(updatedDate.value.toJSDate(), "long")
+    : ""
+})
+
+const deletedDate = computed(() => {
+  return props.comment?.deleted_at
+    ? DateTime.fromISO(props.comment.deleted_at)
+    : undefined
+})
+
+const relativeDeletedTime = computed(() => {
+  return deletedDate.value
+    ? timeAgo.format(deletedDate.value.toJSDate(), "long")
     : ""
 })
 </script>

--- a/client/src/components/atoms/InlineComment.vue
+++ b/client/src/components/atoms/InlineComment.vue
@@ -18,6 +18,7 @@
         class="comment-header"
         @quote-reply-to="initiateQuoteReply"
         @modify-comment="modifyComment(comment)"
+        @delete-comment="deleteComment()"
       />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->
@@ -178,6 +179,13 @@ function modifyComment(comment) {
   isQuoteReplying.value = false
   isModifying.value = true
   commentModify.value = comment
+}
+function deleteComment() {
+  isReplying.value = false
+  isQuoteReplying.value = false
+  isModifying.value = false
+  commentReply.value = null
+  activeComment.value = null
 }
 
 const showReplyButton = computed(() => {

--- a/client/src/components/atoms/InlineComment.vue
+++ b/client/src/components/atoms/InlineComment.vue
@@ -18,7 +18,7 @@
         class="comment-header"
         @quote-reply-to="initiateQuoteReply"
         @modify-comment="modifyComment(comment)"
-        @delete-comment="deleteComment()"
+        @delete-comment="deleteComment"
       />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->

--- a/client/src/components/atoms/OverallComment.vue
+++ b/client/src/components/atoms/OverallComment.vue
@@ -18,7 +18,7 @@
         class="comment-header"
         @quote-reply-to="initiateQuoteReply"
         @modify-comment="modifyComment(comment)"
-        @delete-comment="deleteComment(comment)"
+        @delete-comment="deleteComment"
       />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->

--- a/client/src/components/atoms/OverallComment.vue
+++ b/client/src/components/atoms/OverallComment.vue
@@ -18,6 +18,7 @@
         class="comment-header"
         @quote-reply-to="initiateQuoteReply"
         @modify-comment="modifyComment(comment)"
+        @delete-comment="deleteComment(comment)"
       />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->
@@ -162,6 +163,13 @@ function modifyComment(comment) {
   isQuoteReplying.value = false
   isModifying.value = true
   commentModify.value = comment
+}
+
+function deleteComment() {
+  isModifying.value = false
+  isQuoteReplying.value = false
+  isReplying.value = false
+  commentReply.value = null
 }
 
 const showReplyButton = computed(() => {

--- a/client/src/components/atoms/SubmissionCommentSection.vitest.spec.js
+++ b/client/src/components/atoms/SubmissionCommentSection.vitest.spec.js
@@ -29,6 +29,7 @@ describe("Overall Comments", () => {
                   content:
                     "Commodi ipsam excepturi non excepturi. Dolore quia eum sit neque quibusdam fugiat. Excepturi est enim reprehenderit atque unde rerum eum.",
                   created_at: "2022-06-02T08:18:09Z",
+                  deleted_at: null,
                   created_by: {
                     id: "2",
                     email: "publicationadministrator@meshresearch.net",
@@ -42,6 +43,7 @@ describe("Overall Comments", () => {
                   content:
                     "Fugit id officia facere nesciunt modi beatae beatae. Assumenda culpa consequatur vel autem.",
                   created_at: "2022-06-01T20:57:28Z",
+                  deleted_at: null,
                   created_by: {
                     id: "4",
                     email: "reviewcoordinator@meshresearch.net",
@@ -54,6 +56,7 @@ describe("Overall Comments", () => {
                       content:
                         "Asperiores aut commodi dolorum enim iusto consequatur minima. Neque adipisci animi tempora voluptatem error nam cupiditate.",
                       created_at: "2022-06-02T20:57:28Z",
+                      deleted_at: null,
                       created_by: {
                         id: "6",
                         username: "akihn",
@@ -69,6 +72,7 @@ describe("Overall Comments", () => {
                   content:
                     "Temporibus voluptatem ea aut placeat atque eum. A officia ea eos quo. Ut dolor sequi deserunt quo.",
                   created_at: "2022-06-02T10:38:18Z",
+                  deleted_at: null,
                   updated_at: "2022-06-02T10:38:18Z",
                   created_by: {
                     id: "1",
@@ -87,6 +91,7 @@ describe("Overall Comments", () => {
                       content:
                         "Nihil beatae omnis illum laborum magni quam quia rerum. Quia doloremque fugit ipsa debitis ratione laborum dolorem.",
                       created_at: "2022-06-03T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-03T10:38:18Z",
                       created_by: {
                         id: "4",
@@ -106,6 +111,7 @@ describe("Overall Comments", () => {
                       content:
                         "Sed nostrum est perferendis labore rem molestiae molestiae. Necessitatibus officiis quia labore et eum harum eveniet. Officia ut accusantium non saepe ut.",
                       created_at: "2022-06-04T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-04T10:38:18Z",
                       created_by: {
                         id: "3",
@@ -125,6 +131,7 @@ describe("Overall Comments", () => {
                       content:
                         "Ut labore dignissimos aperiam ipsum et unde velit. Maxime animi quidem perspiciatis nihil possimus qui sequi labore.",
                       created_at: "2022-06-05T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-05T10:38:18Z",
                       created_by: {
                         id: "6",
@@ -144,6 +151,7 @@ describe("Overall Comments", () => {
                       content:
                         "Aut numquam harum dolorem aliquam nulla. Ut tempore numquam modi maiores quia iusto.",
                       created_at: "2022-06-04T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-08-04T05:38:18Z",
                       created_by: {
                         id: "1",
@@ -163,6 +171,7 @@ describe("Overall Comments", () => {
                       content:
                         "Ut praesentium cumque beatae reiciendis laboriosam quia illum alias. Est quasi corrupti eveniet sequi et. Voluptatem ea ut in sed ipsa officiis et.",
                       created_at: "2022-06-05T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-05T10:38:18Z",
                       created_by: {
                         id: "3",
@@ -182,6 +191,7 @@ describe("Overall Comments", () => {
                       content:
                         "Consequuntur dignissimos quibusdam eum placeat est. Aut eos nobis accusantium omnis sapiente.",
                       created_at: "2022-06-03T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-03T10:38:18Z",
                       created_by: {
                         id: "6",
@@ -201,6 +211,7 @@ describe("Overall Comments", () => {
                       content:
                         "Error facere qui vel labore explicabo sint dignissimos. Recusandae minima quia enim fugiat. Suscipit aut voluptate consequatur molestiae omnis sint.",
                       created_at: "2022-06-04T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-04T10:38:18Z",
                       created_by: {
                         id: "7",
@@ -220,6 +231,7 @@ describe("Overall Comments", () => {
                       content:
                         "Est incidunt nisi perferendis magni. Voluptatum ex quae quam dicta earum repellendus.",
                       created_at: "2022-06-05T10:38:18Z",
+                      deleted_at: null,
                       updated_at: "2022-06-05T10:38:18Z",
                       created_by: {
                         id: "5",

--- a/client/src/components/atoms/SubmissionCommentSection.vue
+++ b/client/src/components/atoms/SubmissionCommentSection.vue
@@ -9,7 +9,9 @@
         :comment="comment"
       />
       <q-card class="q-my-md q-pa-md bg-grey-1 comment-editor-card">
-        <h3 class="text-h3 q-mt-none">{{ $t("submissions.overall_comments.editor_heading") }}</h3>
+        <h3 class="text-h3 q-mt-none">
+          {{ $t("submissions.overall_comments.editor_heading") }}
+        </h3>
         <comment-editor
           comment-type="OverallComment"
           data-cy="overallCommentEditor"
@@ -30,7 +32,10 @@ const submission = inject("submission")
 const activeComment = inject("activeComment")
 
 const overall_comments = computed(() => {
-  return submission.value?.overall_comments ?? []
+  const comments = submission.value?.overall_comments ?? []
+  return comments.filter((c) => {
+    return c.deleted_at === null || c.replies.length > 0
+  })
 })
 const commentRefs = ref([])
 watch(
@@ -47,7 +52,7 @@ watch(
         }
         if (commentRef.replyIds.includes(newValue.id)) {
           const reply = commentRef.replyRefs.find(
-            (r) => r.comment.id === newValue.id
+            (r) => r.comment.id === newValue.id,
           )
           scrollTarget = reply.scrollTarget
           break
@@ -70,7 +75,7 @@ watch(
       setVerticalScrollPosition(target, offset - 64, 250)
     })
   },
-  { deep: false }
+  { deep: false },
 )
 </script>
 

--- a/client/src/components/atoms/SubmissionCommentSection.vue
+++ b/client/src/components/atoms/SubmissionCommentSection.vue
@@ -34,7 +34,7 @@ const activeComment = inject("activeComment")
 const overall_comments = computed(() => {
   const comments = submission.value?.overall_comments ?? []
   return comments.filter((c) => {
-    return c.deleted_at === null || c.replies.length > 0
+    return c.deleted_at === null || c.replies?.length > 0
   })
 })
 const commentRefs = ref([])

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -187,13 +187,17 @@ const onAnnotationClick = (context, { target }) => {
 const inlineComments = computed(() => submission.value?.inline_comments ?? [])
 const annotations = computed(() =>
   props.highlightVisibility
-    ? inlineComments.value.map(({ from, to, id }) => ({
+    ? inlineComments.value.map(({ from, to, id, deleted_at }) => deleted_at == null ? ({
         from,
         to,
         context: { id },
         active: id === activeComment.value?.id,
         click: onAnnotationClick,
-      }))
+      }) : {
+        context: { id },
+        active: id === activeComment.value?.id,
+        click: () => false,
+      })
     : [],
 )
 

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -225,6 +225,8 @@ function addComment() {
     from,
     to,
     parent_id: null,
+    reply_to_id: null,
+    deleted_at: null,
     id: "new",
   }
 }

--- a/client/src/components/dialogs/ConfirmCommentDeletion.vue
+++ b/client/src/components/dialogs/ConfirmCommentDeletion.vue
@@ -59,7 +59,7 @@ const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } =
   useDialogPluginComponent()
 
 const mutation =
-  props.comment.__typename == "InlineComment"
+  props.comment.__typename.startsWith("InlineComment")
     ? DELETE_INLINE_COMMENT
     : DELETE_OVERALL_COMMENT
 const { mutate } = useMutation(mutation)

--- a/client/src/components/dialogs/ConfirmCommentDeletion.vue
+++ b/client/src/components/dialogs/ConfirmCommentDeletion.vue
@@ -1,0 +1,49 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <q-card>
+      <q-card-section class="row items-center">
+        <q-avatar icon="delete" color="primary" text-color="white" />
+        <span class="q-ml-sm">{{ $t(`dialog.deleteComment.body`) }}</span>
+      </q-card-section>
+      <q-card-section>
+        <blockquote>
+          {{ props.comment }}
+        </blockquote>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn
+          flat
+          :label="$t(`dialog.deleteComment.cancel`)"
+          color="primary"
+          data-cy="dirtyCancel"
+          @click="onDialogCancel"
+        />
+        <q-btn
+          flat
+          :label="$t(`dialog.deleteComment.delete`)"
+          color="negative"
+          data-cy="dirtyDelete"
+          @click="onDialogOK"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { useDialogPluginComponent } from "quasar"
+
+const props = defineProps({
+  comment: {
+    type: String,
+    default: "",
+    required: false,
+  },
+})
+
+defineEmits([...useDialogPluginComponent.emits])
+
+const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } =
+  useDialogPluginComponent()
+</script>

--- a/client/src/components/dialogs/ConfirmCommentDeletion.vue
+++ b/client/src/components/dialogs/ConfirmCommentDeletion.vue
@@ -2,13 +2,14 @@
   <q-dialog ref="dialogRef" @hide="onDialogHide">
     <q-card>
       <q-card-section class="row items-center">
-        <q-avatar icon="delete" color="primary" text-color="white" />
+        <div class="q-pa-sm q-pr-md column">
+          <q-avatar icon="delete" color="primary" text-color="white" />
+        </div>
         <span class="q-ml-sm">{{ $t(`dialog.deleteComment.body`) }}</span>
       </q-card-section>
       <q-card-section>
-        <blockquote>
-          {{ props.comment }}
-        </blockquote>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <blockquote class="q-mt-none" v-html="props.comment.content"></blockquote>
       </q-card-section>
 
       <q-card-actions align="right">
@@ -20,11 +21,10 @@
           @click="onDialogCancel"
         />
         <q-btn
-          flat
           :label="$t(`dialog.deleteComment.delete`)"
           color="negative"
           data-cy="dirtyDelete"
-          @click="onDialogOK"
+          @click="onDialogOK(deleteComment())"
         />
       </q-card-actions>
     </q-card>
@@ -32,18 +32,46 @@
 </template>
 
 <script setup>
-import { useDialogPluginComponent } from "quasar"
-
-const props = defineProps({
-  comment: {
-    type: String,
-    default: "",
-    required: false,
-  },
-})
-
-defineEmits([...useDialogPluginComponent.emits])
+import { useDialogPluginComponent, useQuasar } from "quasar"
+import { useMutation } from "@vue/apollo-composable"
+import { DELETE_INLINE_COMMENT } from "src/graphql/mutations"
+import { useI18n } from "vue-i18n"
 
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } =
   useDialogPluginComponent()
+const { mutate } = useMutation(DELETE_INLINE_COMMENT)
+const { notify } = useQuasar()
+const { t } = useI18n()
+
+const props = defineProps({
+  comment: {
+    type: Object,
+    default: () => {},
+    required: false,
+  },
+  submissionId: {
+    type: String,
+    required: true,
+  },
+})
+
+async function deleteComment() {
+  try {
+    await mutate({
+      comment_id: String(props.comment.id),
+      submission_id: String(props.submissionId)
+    })
+  } catch (error) {
+    notify({
+      color: "negative",
+      message: t("dialog.deleteComment.failure"),
+      icon: "error",
+      attrs: {
+        "data-cy": "delete_comment_notify",
+      },
+    })
+  }
+}
+
+defineEmits([...useDialogPluginComponent.emits])
 </script>

--- a/client/src/components/molecules/InlineComments.vitest.spec.js
+++ b/client/src/components/molecules/InlineComments.vitest.spec.js
@@ -29,6 +29,7 @@ describe("InlineComments", () => {
                   content:
                     "Excepturi consectetur autem temporibus modi. Ipsum unde reiciendis ipsa quidem. Nihil nisi sint ut et.",
                   created_at: "2022-06-01T03:53:17Z",
+                  deleted_at: null,
                   created_by: {
                     id: "2",
                     email: "publicationadministrator@meshresearch.net",
@@ -41,6 +42,7 @@ describe("InlineComments", () => {
                       content:
                         "Sed ullam culpa dolore ea qui. Enim voluptatem eos voluptas et est.",
                       created_at: "2022-06-02T03:53:17Z",
+                      deleted_at: null,
                       created_by: {
                         id: "1",
                         username: "applicationAdminUser",
@@ -64,6 +66,7 @@ describe("InlineComments", () => {
                   content:
                     "Iure itaque non illo et. Et assumenda quasi doloribus natus vitae. Cupiditate aut exercitationem rerum quidem iusto occaecati saepe.",
                   created_at: "2022-05-30T19:20:59Z",
+                  deleted_at: null,
                   created_by: {
                     id: "6",
                     email: "gracie91@example.net",
@@ -97,6 +100,7 @@ describe("InlineComments", () => {
                   content:
                     "Quia ea numquam delectus sapiente in molestiae. Omnis placeat impedit doloribus atque. Beatae est repellat officia magnam molestiae similique.",
                   created_at: "2022-05-31T16:28:10Z",
+                  deleted_at: null,
                   created_by: {
                     id: "7",
                     email: "hessel.russell@example.net",
@@ -109,6 +113,7 @@ describe("InlineComments", () => {
                       content:
                         "Repudiandae voluptatem voluptatum in quia quos. Molestiae molestias fugit distinctio sed deserunt culpa itaque. Autem quo accusantium autem eaque autem.",
                       created_at: "2022-06-01T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "3",
                         username: "publicationEditor",
@@ -122,6 +127,7 @@ describe("InlineComments", () => {
                       content:
                         "Voluptatem earum deleniti non possimus et libero. Illo a quia est perferendis libero ipsa.",
                       created_at: "2022-06-02T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "4",
                         username: "reviewCoordinator",
@@ -135,6 +141,7 @@ describe("InlineComments", () => {
                       content:
                         "Id temporibus quia ut placeat at qui nemo. Dolorum numquam consequatur amet repellat veniam enim aliquam.",
                       created_at: "2022-06-01T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "7",
                         username: "rschoen",
@@ -148,6 +155,7 @@ describe("InlineComments", () => {
                       content:
                         "Autem blanditiis labore ducimus rerum assumenda. Quam deleniti nesciunt voluptas aut alias. Magni est ut ea rerum.",
                       created_at: "2022-06-02T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "1",
                         username: "applicationAdminUser",
@@ -161,6 +169,7 @@ describe("InlineComments", () => {
                       content:
                         "Et velit hic voluptate illo praesentium dicta. Dolores repudiandae qui non et consequatur et et autem. Laudantium qui sint accusantium soluta facilis esse ut.",
                       created_at: "2022-06-01T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "1",
                         username: "applicationAdminUser",
@@ -174,6 +183,7 @@ describe("InlineComments", () => {
                       content:
                         "Odit ut nihil similique accusamus a et deleniti quam. Non voluptates quis ipsa voluptatem. Voluptas reprehenderit id aut ab officia facere.",
                       created_at: "2022-06-03T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "1",
                         username: "applicationAdminUser",
@@ -187,6 +197,7 @@ describe("InlineComments", () => {
                       content:
                         "Et aut voluptates alias dicta ut quis. Illum dolore occaecati quia ut excepturi autem. Rem ratione molestias perspiciatis est.",
                       created_at: "2022-06-02T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "1",
                         username: "applicationAdminUser",
@@ -200,6 +211,7 @@ describe("InlineComments", () => {
                       content:
                         "Rerum est aut ratione expedita vitae earum. Vel aliquid eum quia corporis quidem nisi enim consequatur.",
                       created_at: "2022-06-03T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "5",
                         username: "regularUser",
@@ -213,6 +225,7 @@ describe("InlineComments", () => {
                       content:
                         "Aut est unde dolores assumenda. Cum consectetur corrupti quaerat vel ab ea hic. Quasi repellat dolor ducimus omnis.",
                       created_at: "2022-06-02T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "4",
                         username: "reviewCoordinator",
@@ -226,6 +239,7 @@ describe("InlineComments", () => {
                       content:
                         "Porro minima et laboriosam non. Perspiciatis quis doloremque ut saepe neque.",
                       created_at: "2022-06-01T16:28:10Z",
+                      deleted_at: null,
                       created_by: {
                         id: "3",
                         username: "publicationEditor",

--- a/client/src/components/molecules/InlineComments.vue
+++ b/client/src/components/molecules/InlineComments.vue
@@ -52,7 +52,9 @@ const inline_comments = computed(() => {
   if (activeComment.value?.new === true) {
     comments.push(activeComment.value)
   }
-  return comments.sort((a, b) => {
+  return comments.filter((c) => {
+    return c.deleted_at === null || c.replies.length > 0
+  }).sort((a, b) => {
     return a.from - b.from
   })
 })

--- a/client/src/components/molecules/InlineComments.vue
+++ b/client/src/components/molecules/InlineComments.vue
@@ -53,7 +53,7 @@ const inline_comments = computed(() => {
     comments.push(activeComment.value)
   }
   return comments.filter((c) => {
-    return c.deleted_at === null || c.replies.length > 0
+    return c.deleted_at === null || c.replies?.length > 0
   }).sort((a, b) => {
     return a.from - b.from
   })

--- a/client/src/graphql/fragments.js
+++ b/client/src/graphql/fragments.js
@@ -62,6 +62,7 @@ export const _COMMENT_FIELDS = gql`
     content
     created_at
     updated_at
+    deleted_at
     updated_by {
       ...relatedUserFields
     }

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -473,9 +473,9 @@ export const CREATE_OVERALL_COMMENT = gql`
       }
     ) {
       id
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           ...commentFields
           reply_to_id
         }
@@ -507,9 +507,9 @@ export const CREATE_OVERALL_COMMENT_REPLY = gql`
       }
     ) {
       id
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -548,7 +548,7 @@ export const CREATE_INLINE_COMMENT = gql`
           icon
         }
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -586,7 +586,7 @@ export const CREATE_INLINE_COMMENT_REPLY = gql`
           icon
         }
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -696,9 +696,9 @@ export const UPDATE_OVERALL_COMMENT = gql`
       created_by {
         ...relatedUserFields
       }
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -738,7 +738,7 @@ export const UPDATE_INLINE_COMMENT = gql`
           name
           icon
         }
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -767,7 +767,7 @@ export const UPDATE_INLINE_COMMENT_REPLY = gql`
       }
       inline_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -793,7 +793,7 @@ export const DELETE_INLINE_COMMENT = gql`
           name
           icon
         }
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           parent_id
           ...commentFields
@@ -821,9 +821,9 @@ export const UPDATE_OVERALL_COMMENT_REPLY = gql`
       created_by {
         ...relatedUserFields
       }
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           ...commentFields
         }
@@ -845,7 +845,7 @@ export const DELETE_OVERALL_COMMENT = gql`
       }
       overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           reply_to_id
           parent_id
           ...commentFields

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -477,6 +477,7 @@ export const CREATE_OVERALL_COMMENT = gql`
         ...commentFields
         replies(trashed: WITH) {
           ...commentFields
+          parent_id
           reply_to_id
         }
       }
@@ -552,6 +553,7 @@ export const CREATE_INLINE_COMMENT = gql`
         ...commentFields
         replies(trashed: WITH) {
           ...commentFields
+          parent_id
           reply_to_id
         }
       }

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -836,17 +836,18 @@ export const UPDATE_OVERALL_COMMENT_REPLY = gql`
 
 export const DELETE_OVERALL_COMMENT = gql`
   mutation DeleteOverallComment($submission_id: ID!, $comment_id: ID!) {
-    updateSubmission(
-      input: { id: $submission_id, overall_comments: { delete: $comment_id } }
+    deleteOverallComment(
+      input: { submission_id: $submission_id, comment_id: $comment_id }
     ) {
       id
       created_by {
         ...relatedUserFields
       }
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
         replies {
           reply_to_id
+          parent_id
           ...commentFields
         }
       }

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -510,14 +510,16 @@ export const CREATE_OVERALL_COMMENT_REPLY = gql`
       overall_comments(trashed: WITH) {
         ...commentFields
         replies(trashed: WITH) {
-          reply_to_id
           ...commentFields
+          parent_id
+          reply_to_id
         }
       }
     }
   }
   ${_COMMENT_FIELDS}
 `
+
 export const CREATE_INLINE_COMMENT = gql`
   mutation CreateInlineCommentReply(
     $submission_id: ID!
@@ -549,8 +551,8 @@ export const CREATE_INLINE_COMMENT = gql`
         }
         ...commentFields
         replies(trashed: WITH) {
-          reply_to_id
           ...commentFields
+          reply_to_id
         }
       }
     }
@@ -587,8 +589,9 @@ export const CREATE_INLINE_COMMENT_REPLY = gql`
         }
         ...commentFields
         replies(trashed: WITH) {
-          reply_to_id
           ...commentFields
+          parent_id
+          reply_to_id
         }
       }
     }
@@ -824,8 +827,9 @@ export const UPDATE_OVERALL_COMMENT_REPLY = gql`
       overall_comments(trashed: WITH) {
         ...commentFields
         replies(trashed: WITH) {
-          reply_to_id
           ...commentFields
+          reply_to_id
+          parent_id
         }
       }
     }

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -228,7 +228,10 @@ export const UPDATE_SUBMISSION_CONTENT = gql`
 `
 
 export const UPDATE_SUBMISSION_CONTENT_WITH_FILE = gql`
-  mutation UpdateSubmissionContentWithFile($submission_id: ID!, $file_upload: Upload!) {
+  mutation UpdateSubmissionContentWithFile(
+    $submission_id: ID!
+    $file_upload: Upload!
+  ) {
     updateSubmissionContentWithFile(
       input: { submission_id: $submission_id, file_upload: $file_upload }
     ) {
@@ -324,7 +327,7 @@ export const UPDATE_PROFILE_METADATA = gql`
         username: $username
         name: $name
         profile_metadata: $profile_metadata
-        }
+      }
     ) {
       id
       ...profileMetadata
@@ -775,6 +778,38 @@ export const UPDATE_INLINE_COMMENT_REPLY = gql`
   ${_RELATED_USER_FIELDS}
 `
 
+export const DELETE_INLINE_COMMENT = gql`
+  mutation DeleteInlineComment(
+    $submission_id: ID!
+    $comment_id: ID!
+  ) {
+    updateSubmission(
+      input: {
+        id: $submission_id
+        inline_comments: { delete: { id: $comment_id } }
+      }
+    ) {
+      id
+      created_by {
+        ...relatedUserFields
+      }
+      inline_comments {
+        ...commentFields
+        style_criteria {
+          name
+          icon
+        }
+        replies {
+          reply_to_id
+          ...commentFields
+        }
+      }
+    }
+  }
+  ${_COMMENT_FIELDS}
+  ${_RELATED_USER_FIELDS}
+`
+
 export const UPDATE_OVERALL_COMMENT_REPLY = gql`
   mutation UpdateInlineCommentReply(
     $submission_id: ID!
@@ -785,6 +820,34 @@ export const UPDATE_OVERALL_COMMENT_REPLY = gql`
       input: {
         id: $submission_id
         overall_comments: { update: { id: $comment_id, content: $content } }
+      }
+    ) {
+      id
+      created_by {
+        ...relatedUserFields
+      }
+      overall_comments {
+        ...commentFields
+        replies {
+          reply_to_id
+          ...commentFields
+        }
+      }
+    }
+  }
+  ${_COMMENT_FIELDS}
+  ${_RELATED_USER_FIELDS}
+`
+
+export const DELETE_OVERALL_COMMENT = gql`
+  mutation DeleteOverallComment(
+    $submission_id: ID!
+    $comment_id: ID!
+  ) {
+    updateSubmission(
+      input: {
+        id: $submission_id
+        overall_comments: { delete: $comment_id } }
       }
     ) {
       id

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -795,6 +795,7 @@ export const DELETE_INLINE_COMMENT = gql`
         }
         replies {
           reply_to_id
+          parent_id
           ...commentFields
         }
       }

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -779,15 +779,9 @@ export const UPDATE_INLINE_COMMENT_REPLY = gql`
 `
 
 export const DELETE_INLINE_COMMENT = gql`
-  mutation DeleteInlineComment(
-    $submission_id: ID!
-    $comment_id: ID!
-  ) {
-    updateSubmission(
-      input: {
-        id: $submission_id
-        inline_comments: { delete: $comment_id }
-      }
+  mutation DeleteInlineComment($submission_id: ID!, $comment_id: ID!) {
+    deleteInlineComment(
+      input: { submission_id: $submission_id, comment_id: $comment_id }
     ) {
       id
       created_by {
@@ -840,15 +834,9 @@ export const UPDATE_OVERALL_COMMENT_REPLY = gql`
 `
 
 export const DELETE_OVERALL_COMMENT = gql`
-  mutation DeleteOverallComment(
-    $submission_id: ID!
-    $comment_id: ID!
-  ) {
+  mutation DeleteOverallComment($submission_id: ID!, $comment_id: ID!) {
     updateSubmission(
-      input: {
-        id: $submission_id
-        overall_comments: { delete: $comment_id }
-      }
+      input: { id: $submission_id, overall_comments: { delete: $comment_id } }
     ) {
       id
       created_by {

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -542,7 +542,7 @@ export const CREATE_INLINE_COMMENT = gql`
       }
     ) {
       id
-      inline_comments {
+      inline_comments(trashed: WITH) {
         style_criteria {
           name
           icon
@@ -580,7 +580,7 @@ export const CREATE_INLINE_COMMENT_REPLY = gql`
       }
     ) {
       id
-      inline_comments {
+      inline_comments(trashed: WITH) {
         style_criteria {
           name
           icon
@@ -732,7 +732,7 @@ export const UPDATE_INLINE_COMMENT = gql`
       created_by {
         ...relatedUserFields
       }
-      inline_comments {
+      inline_comments(trashed: WITH) {
         ...commentFields
         style_criteria {
           name
@@ -765,7 +765,7 @@ export const UPDATE_INLINE_COMMENT_REPLY = gql`
       created_by {
         ...relatedUserFields
       }
-      inline_comments {
+      inline_comments(trashed: WITH) {
         ...commentFields
         replies {
           reply_to_id
@@ -787,7 +787,7 @@ export const DELETE_INLINE_COMMENT = gql`
       created_by {
         ...relatedUserFields
       }
-      inline_comments {
+      inline_comments(trashed: WITH) {
         ...commentFields
         style_criteria {
           name

--- a/client/src/graphql/mutations.js
+++ b/client/src/graphql/mutations.js
@@ -786,7 +786,7 @@ export const DELETE_INLINE_COMMENT = gql`
     updateSubmission(
       input: {
         id: $submission_id
-        inline_comments: { delete: { id: $comment_id } }
+        inline_comments: { delete: $comment_id }
       }
     ) {
       id
@@ -847,7 +847,7 @@ export const DELETE_OVERALL_COMMENT = gql`
     updateSubmission(
       input: {
         id: $submission_id
-        overall_comments: { delete: $comment_id } }
+        overall_comments: { delete: $comment_id }
       }
     ) {
       id

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -90,7 +90,7 @@ export const CURRENT_USER_SUBMISSIONS = gql`
         submitters {
           ...relatedUserFields
         }
-        inline_comments {
+        inline_comments(trashed: WITH) {
           id
           content
           created_by {
@@ -127,7 +127,7 @@ export const CURRENT_USER_SUBMISSIONS = gql`
             updated_at
           }
         }
-        overall_comments {
+        overall_comments(trashed: WITH) {
           id
           content
           created_by {
@@ -391,7 +391,7 @@ export const GET_SUBMISSION_REVIEW = gql`
           reply_to_id
         }
       }
-      overall_comments {
+      overall_comments(trashed: WITH) {
         ...commentFields
         replies {
           ...commentFields

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -386,15 +386,17 @@ export const GET_SUBMISSION_REVIEW = gql`
           name
           icon
         }
-        replies {
+        replies(trashed: WITH) {
           ...commentFields
+          parent_id
           reply_to_id
         }
       }
       overall_comments(trashed: WITH) {
         ...commentFields
-        replies {
+        replies(trashed: WITH) {
           ...commentFields
+          parent_id
           reply_to_id
         }
       }

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -376,7 +376,8 @@ export const GET_SUBMISSION_REVIEW = gql`
           ...relatedUserFields
         }
       }
-      inline_comments {
+      inline_comments(trashed: WITH) {
+        deleted_at
         from
         to
         ...commentFields

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -944,7 +944,8 @@
       "actions": {
         "quote_reply": "Quote Reply",
         "modify": "Modify",
-        "share": "Share"
+        "share": "Share",
+        "delete": "Delete"
       },
       "placeholder": "Add a comment …",
       "scroll_to_top": "Scroll to top"

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1154,7 +1154,8 @@
     "deleteComment": {
       "body": "Are you sure you want to delete this comment?",
       "delete": "Delete",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "failure": "Something went wrong while attempting to delete this comment."
     }
   },
   "generic": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1150,6 +1150,11 @@
       "body": "Are you sure you want to discard your changes?",
       "keep_changes": "Keep Changes",
       "discard": "Discard"
+    },
+    "deleteComment": {
+      "body": "Are you sure you want to delete this comment?",
+      "delete": "Delete",
+      "cancel": "Cancel"
     }
   },
   "generic": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -928,6 +928,7 @@
     "comment": {
       "ariaLabel": "Comment. Author {username}. {replies} replies",
       "dateLabel": "Created {date}",
+      "dateLabelDeleted": "Deleted {date}",
       "dateLabelUpdated": "Updated {date}",
       "updatedLabel": "Updated",
       "toggle_replies": {

--- a/client/test/cypress/integration/admin/publication_setup.cy.js
+++ b/client/test/cypress/integration/admin/publication_setup.cy.js
@@ -178,7 +178,7 @@ describe("Publication Setup", () => {
     cy.dataCy('listItem').should('have.length', 3)
   });
 
-  it.only("should allow editing basic settings", () => {
+  it("should allow editing basic settings", () => {
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("publication/1/setup/basic")
 

--- a/client/test/cypress/integration/admin/publication_setup.cy.js
+++ b/client/test/cypress/integration/admin/publication_setup.cy.js
@@ -107,7 +107,7 @@ describe("Publication Setup", () => {
 
   })
 
-  it.only("should allow editing of style criteria", () => {
+  it("should allow editing of style criteria", () => {
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("publication/1/setup/criteria")
     cy.injectAxe()

--- a/client/test/cypress/integration/admin/publication_setup.cy.js
+++ b/client/test/cypress/integration/admin/publication_setup.cy.js
@@ -107,7 +107,7 @@ describe("Publication Setup", () => {
 
   })
 
-  it("should allow editing of style criteria", () => {
+  it.only("should allow editing of style criteria", () => {
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("publication/1/setup/criteria")
     cy.injectAxe()
@@ -134,7 +134,7 @@ describe("Publication Setup", () => {
       cy.dataCy("button_save").click()
 
       //Wait for the form to go away
-      cy.get('form[.data-cy="listItem"]:first').should('not.exist')
+      cy.get('form[data-cy="listItem"]').should('not.exist')
       cy.dataCy("listItem").first().contains("Accessibility Update")
       cy.dataCy("listItem").first().contains("Updated description")
       cy.dataCy("listItem").first().contains(newIconName)

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -72,7 +72,7 @@ describe("Submissions Review", () => {
     cy.dataCy("overallComment").last().contains("This is an overall comment.")
   })
 
-  it("should allow a reviewer to submit overall comment replies", () => {
+  it.only("should allow a reviewer to submit overall comment replies", () => {
     cy.task("resetDb")
     cy.login({ email: "reviewer@meshresearch.net" })
     cy.visit("submission/100/review")

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -105,17 +105,17 @@ describe("Submissions Review", () => {
     cy.dataCy("overallComment").eq(2).find("[data-cy=showRepliesButton]").click()
     cy.dataCy("overallCommentReply").eq(2).find("[data-cy=commentActions]").click()
     cy.dataCy("quoteReply").click()
-    cy.dataCy("overallCommentReplyEditor").eq(2).type("This is a reply to an overall comment reply.")
+    cy.dataCy("overallCommentReplyEditor").eq(0).type("This is a reply to an overall comment reply.")
     // Create a reply to an overall comment reply
 
-    cy.dataCy("overallCommentReplyEditor").eq(2).find("button[type=submit]").click()
+    cy.dataCy("overallCommentReplyEditor").eq(0).find("button[type=submit]").click()
     cy.wait("@CreateOverallCommentReply")
     //   8 overall comment replies are already visible in this thread from database seeding
     // + 0 disallowed empty overall comment reply creation attempt
     // + 1 newly created overall comment reply
     // = 9
     cy.dataCy("overallCommentReply").should('have.length', 9)
-    cy.dataCy("overallCommentReply").eq(2).contains("This is a reply to an overall comment reply.")
+    cy.dataCy("overallCommentReply").last().contains("This is a reply to an overall comment reply.")
   })
 
   it("should allow a reviewer to submit inline comment replies", () => {
@@ -258,7 +258,7 @@ describe("Submissions Review", () => {
     cy.dataCy("decision_options").should('not.exist');
   })
 
-  it("should allow overall comments to be modified", () => {
+  it.only("should allow overall comments to be modified", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("submission/100/review")
@@ -271,7 +271,7 @@ describe("Submissions Review", () => {
 
     // click on modifyComment
     cy.dataCy("overallComment")
-      .should('have.length', 4)
+      .should('have.length', 5)
       .last()
       .find("[data-cy=commentActions]")
       .click()

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -461,7 +461,7 @@ describe("Submissions Review", () => {
     cy.dataCy("inlineComment").first().contains("This comment has been deleted").click()
   })
 
-  it.only("allows an overall comment to be deleted by its author", () => {
+  it("allows an overall comment to be deleted by its author", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("submission/100/review")

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -449,4 +449,25 @@ describe("Submissions Review", () => {
     cy.dataCy("submission_status").contains("Deleted")
     cy.dataCy("status-dropdown").should('not.exist')
   })
+
+  it("allows an inline comment to be deleted by its author", () => {
+    cy.task("resetDb")
+    cy.login({ email: "applicationadministrator@meshresearch.net" })
+    cy.visit("submission/100/review")
+    cy.dataCy("toggleInlineCommentsButton").click()
+    cy.dataCy("inlineComment").first().find("[data-cy=commentActions]").click()
+    cy.dataCy("deleteComment").click()
+    cy.dataCy("dirtyDelete").click()
+    cy.dataCy("inlineComment").first().contains("This comment has been deleted").click()
+  })
+
+  it.only("allows an overall comment to be deleted by its author", () => {
+    cy.task("resetDb")
+    cy.login({ email: "applicationadministrator@meshresearch.net" })
+    cy.visit("submission/100/review")
+    cy.dataCy("overallComment").last().find("[data-cy=commentActions]").click()
+    cy.dataCy("deleteComment").click()
+    cy.dataCy("dirtyDelete").click()
+    cy.dataCy("overallComment").last().contains("This comment has been deleted").click()
+  })
 })

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -258,7 +258,7 @@ describe("Submissions Review", () => {
     cy.dataCy("decision_options").should('not.exist');
   })
 
-  it.only("should allow overall comments to be modified", () => {
+  it("should allow overall comments to be modified", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@meshresearch.net" })
     cy.visit("submission/100/review")

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -64,11 +64,11 @@ describe("Submissions Review", () => {
     cy.dataCy("overallCommentEditor").find("button[type=submit]").click()
 
     cy.wait("@CreateOverallComment")
-    //   3 overall comment parents already exist from database seeding
+    //   4 overall comment parents already exist from database seeding
     // + 0 disallowed empty overall comment creation attempt
     // + 1 newly created overall comment
-    // = 4
-    cy.dataCy("overallComment").should('have.length', 4)
+    // = 5
+    cy.dataCy("overallComment").should('have.length', 5)
     cy.dataCy("overallComment").last().contains("This is an overall comment.")
   })
 
@@ -87,7 +87,7 @@ describe("Submissions Review", () => {
 
     cy.dataCy("overallCommentReplyEditor").first().find("button[type=submit]").click()
     cy.wait("@CreateOverallCommentReply")
-    //   0 overall comment replies already exist from database seeding
+    //   0 replies to the first overall comment already exist from database seeding
     // + 0 disallowed empty overall comment reply creation attempt
     // + 1 newly created overall comment reply
     // = 1
@@ -102,20 +102,20 @@ describe("Submissions Review", () => {
     cy.visit("submission/100/review")
 
     cy.interceptGQLOperation("CreateOverallCommentReply")
-    cy.dataCy("overallComment").last().find("[data-cy=showRepliesButton]").click()
-    cy.dataCy("overallCommentReply").last().find("[data-cy=commentActions]").click()
+    cy.dataCy("overallComment").eq(2).find("[data-cy=showRepliesButton]").click()
+    cy.dataCy("overallCommentReply").eq(2).find("[data-cy=commentActions]").click()
     cy.dataCy("quoteReply").click()
-    cy.dataCy("overallCommentReplyEditor").last().type("This is a reply to an overall comment reply.")
+    cy.dataCy("overallCommentReplyEditor").eq(2).type("This is a reply to an overall comment reply.")
     // Create a reply to an overall comment reply
 
-    cy.dataCy("overallCommentReplyEditor").last().find("button[type=submit]").click()
+    cy.dataCy("overallCommentReplyEditor").eq(2).find("button[type=submit]").click()
     cy.wait("@CreateOverallCommentReply")
     //   8 overall comment replies are already visible in this thread from database seeding
     // + 0 disallowed empty overall comment reply creation attempt
     // + 1 newly created overall comment reply
     // = 9
     cy.dataCy("overallCommentReply").should('have.length', 9)
-    cy.dataCy("overallCommentReply").last().contains("This is a reply to an overall comment reply.")
+    cy.dataCy("overallCommentReply").eq(2).contains("This is a reply to an overall comment reply.")
   })
 
   it("should allow a reviewer to submit inline comment replies", () => {

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -72,7 +72,7 @@ describe("Submissions Review", () => {
     cy.dataCy("overallComment").last().contains("This is an overall comment.")
   })
 
-  it.only("should allow a reviewer to submit overall comment replies", () => {
+  it("should allow a reviewer to submit overall comment replies", () => {
     cy.task("resetDb")
     cy.login({ email: "reviewer@meshresearch.net" })
     cy.visit("submission/100/review")


### PR DESCRIPTION
This pull request:

* Adds functionality for deleting overall and inline comments and their replies by their authors
    * Comments are soft deleted so that they can be recovered by a system administrator if necessary
* Extends the `replies` attribute of inline and overall comment replies to include their own replies 
* Extends `SubmissionPolicy` to ensure that only the authors of comments can delete them
* Ensures that sensitive data of soft deleted comments are transformed when accessed by the client. This includes
    * `username` becomes `""`
    * `content` becomes `"This comment has been deleted"`
    * `style_criteria` becomes `[]`
* Updates various queries of comments throughout to include soft deleted comments
* Enables soft deleting on the `inline_comments` and `overall_comments` tables
* Fixes an oversight in `InlineCommentSeeder` that prevented inline comment replies from being correctly associated with the same submission of the inline comments they're replying to
* Updates the Submission Review page to conditionally display soft deleted comments
    * If deleted comments have replies, they will be displayed. Otherwise, they're hidden.
* Replaces the nonfunctional "Share" action in the comment action menu with "Delete"
* Adds a seeded overall comment from Application Administrator for testing

Closes #1034 