### PR TITLE
feat: Bidirectional Inline Comment Navigation

### DIFF
--- a/client/src/components/atoms/CommentHeader.vue
+++ b/client/src/components/atoms/CommentHeader.vue
@@ -17,8 +17,9 @@
       </span>
     </div>
   </q-card-section>
-  <q-card-section v-else class="q-py-xs" :style="style">
+  <q-card-section v-else :class="comment.__typename == 'InlineComment' ? 'q-py-xs q-pl-xs' : 'q-py-xs'" :style="style">
     <div class="row items-center">
+      <inline-comment-reference v-if="comment.__typename == 'InlineComment'" :comment="comment" />
       <avatar-image
         :user="comment.created_by"
         round
@@ -73,6 +74,7 @@
 <script setup>
 import AvatarImage from "./AvatarImage.vue"
 import CommentActions from "./CommentActions.vue"
+import InlineCommentReference from "./InlineCommentReference.vue"
 import { useTimeAgo } from "src/use/timeAgo"
 import { DateTime } from "luxon"
 import { computed } from "vue"

--- a/client/src/components/atoms/InlineComment.vue
+++ b/client/src/components/atoms/InlineComment.vue
@@ -116,7 +116,6 @@
           @click="initiateReply"
         />
       </q-card-actions>
-
     </q-card>
   </div>
 </template>

--- a/client/src/components/atoms/InlineComment.vue
+++ b/client/src/components/atoms/InlineComment.vue
@@ -20,6 +20,7 @@
         @modify-comment="modifyComment(comment)"
         @delete-comment="deleteComment"
       />
+      <inline-comment-reference :comment="comment" />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->
         <div v-html="comment.content" />
@@ -124,6 +125,7 @@ import { ref, computed, inject, provide } from "vue"
 import CommentHeader from "./CommentHeader.vue"
 import InlineCommentReply from "./InlineCommentReply.vue"
 import CommentEditor from "../forms/CommentEditor.vue"
+import InlineCommentReference from "./InlineCommentReference.vue"
 
 const isCollapsed = ref(true)
 const isReplying = ref(false)

--- a/client/src/components/atoms/InlineComment.vue
+++ b/client/src/components/atoms/InlineComment.vue
@@ -20,7 +20,6 @@
         @modify-comment="modifyComment(comment)"
         @delete-comment="deleteComment"
       />
-      <inline-comment-reference :comment="comment" />
       <q-card-section v-if="!isModifying">
         <!-- eslint-disable-next-line vue/no-v-html -->
         <div v-html="comment.content" />
@@ -117,6 +116,7 @@
           @click="initiateReply"
         />
       </q-card-actions>
+
     </q-card>
   </div>
 </template>
@@ -125,7 +125,6 @@ import { ref, computed, inject, provide } from "vue"
 import CommentHeader from "./CommentHeader.vue"
 import InlineCommentReply from "./InlineCommentReply.vue"
 import CommentEditor from "../forms/CommentEditor.vue"
-import InlineCommentReference from "./InlineCommentReference.vue"
 
 const isCollapsed = ref(true)
 const isReplying = ref(false)

--- a/client/src/components/atoms/InlineCommentReference.vue
+++ b/client/src/components/atoms/InlineCommentReference.vue
@@ -1,5 +1,6 @@
 <template>
   <q-btn
+    :aria-label="$t(`submissions.comment.reference.go_to_highlight`)"
     dense
     flat
     color="primary"
@@ -13,7 +14,7 @@
 </template>
 
 <script setup>
-import { computed, inject, nextTick } from "vue"
+import { inject, nextTick } from "vue"
 
 const props = defineProps({
   comment: {
@@ -22,9 +23,6 @@ const props = defineProps({
   },
 })
 
-const referencedComment = computed(() => {
-  return props.comment.reply_to_id
-})
 const activeComment = inject("activeComment")
 
 function setActive() {
@@ -32,7 +30,7 @@ function setActive() {
   //TODO: Do this in a more elegant way.
   activeComment.value = null
   nextTick(() => {
-    activeComment.value = referencedComment.value
+    activeComment.value = props.comment
   })
 }
 </script>

--- a/client/src/components/atoms/InlineCommentReference.vue
+++ b/client/src/components/atoms/InlineCommentReference.vue
@@ -1,20 +1,15 @@
 <template>
-  <q-card-section class="q-pa-sm">
-    <q-btn
-      dense
-      flat
-      icon="subdirectory_arrow_right"
-      color="accent"
-      class="q-px-sm q-ml-sm"
-      no-caps
-      :aria-label="$t('submissions.comment.reply.referenceButtonAria')"
-      @click="setActive"
-    >
-      <div>
-        {{ $t("submissions.comment.reference.go_to_highlight") }}
-      </div>
-    </q-btn>
-  </q-card-section>
+  <q-btn
+    dense
+    flat
+    color="primary"
+    class="q-mr-xs"
+    no-caps
+    @click="setActive"
+  >
+    <q-icon size="xs" name="mode_comment"></q-icon>
+    <q-tooltip>{{ $t(`submissions.comment.reference.go_to_highlight`) }}</q-tooltip>
+  </q-btn>
 </template>
 
 <script setup>

--- a/client/src/components/atoms/InlineCommentReference.vue
+++ b/client/src/components/atoms/InlineCommentReference.vue
@@ -1,28 +1,17 @@
 <template>
-  <q-card-section v-if="referencedComment" class="q-pa-none">
+  <q-card-section class="q-pa-sm">
     <q-btn
       dense
       flat
       icon="subdirectory_arrow_right"
       color="accent"
-      class="q-pl-sm q-ml-md"
+      class="q-px-sm q-ml-sm"
       no-caps
       :aria-label="$t('submissions.comment.reply.referenceButtonAria')"
       @click="setActive"
     >
-      <avatar-image
-        :user="referencedComment.created_by"
-        round
-        size="15px"
-        class="q-mr-sm"
-      />
-
       <div>
-        {{
-          $t("submissions.comment.reference.in_reply_to", {
-            username: referencedComment.created_by.username,
-          })
-        }}
+        {{ $t("submissions.comment.reference.go_to_highlight") }}
       </div>
     </q-btn>
   </q-card-section>
@@ -30,23 +19,16 @@
 
 <script setup>
 import { computed, inject, nextTick } from "vue"
-import AvatarImage from "./AvatarImage.vue"
 
 const props = defineProps({
   comment: {
     type: Object,
     required: true,
   },
-  replies: {
-    type: Array,
-    required: true,
-  },
 })
 
 const referencedComment = computed(() => {
   return props.comment.reply_to_id
-    ? props.replies.find((e) => e.id === props.comment.reply_to_id)
-    : null
 })
 const activeComment = inject("activeComment")
 

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -69,7 +69,9 @@
           text-color="grey-7"
           @click="scrollToOverallComments()"
         />
-        <q-tooltip>{{ $t("submissions.style_controls.view_overall") }}</q-tooltip>
+        <q-tooltip>{{
+          $t("submissions.style_controls.view_overall")
+        }}</q-tooltip>
       </div>
       <div>
         <q-btn
@@ -82,7 +84,9 @@
           text-color="grey-7"
           @click="scrollNewOverallComment()"
         />
-        <q-tooltip>{{ $t("submissions.style_controls.new_overall") }}</q-tooltip>
+        <q-tooltip>{{
+          $t("submissions.style_controls.new_overall")
+        }}</q-tooltip>
       </div>
     </div>
   </div>
@@ -154,7 +158,7 @@ function toggleDarkMode() {
 
 const emit = defineEmits([
   "scrollToOverallComments",
-  "scrollAddNewOverallComment"
+  "scrollAddNewOverallComment",
 ])
 
 function scrollToOverallComments() {
@@ -230,17 +234,21 @@ const onAnnotationClick = (context, { target }) => {
 const inlineComments = computed(() => submission.value?.inline_comments ?? [])
 const annotations = computed(() =>
   props.highlightVisibility
-    ? inlineComments.value.map(({ from, to, id, deleted_at }) => deleted_at == null ? ({
-        from,
-        to,
-        context: { id },
-        active: id === activeComment.value?.id,
-        click: onAnnotationClick,
-      }) : {
-        context: { id },
-        active: id === activeComment.value?.id,
-        click: () => false,
-      })
+    ? inlineComments.value.map(({ from, to, id, deleted_at }) =>
+        deleted_at == null
+          ? {
+              from,
+              to,
+              context: { id },
+              active: id === activeComment.value?.id,
+              click: onAnnotationClick,
+            }
+          : {
+              context: { id },
+              active: id === activeComment.value?.id,
+              click: () => false,
+            },
+      )
     : [],
 )
 
@@ -292,13 +300,15 @@ watch(
     nextTick(() => {
       let scrollTarget = null
       scrollTarget = contentRef.value.querySelector(
-        `button[data-comment="${newValue.id}"]`
+        `button[data-comment="${newValue.id}"]`,
       )
       if (!scrollTarget) return
       const getOffsetTop = function (element) {
         if (!element) return 0
         return getOffsetTop(element.offsetParent) + element.offsetTop
       }
+      const getOffset = scrollTarget.getBoundingClientRect().top
+      if (getOffset > 200 && getOffset < 500) return
       const primaryNavHeight = 70
       const secondaryNavHeight = 48
       const tertiaryNavHeight = 75
@@ -313,9 +323,8 @@ watch(
       setVerticalScrollPosition(target, offset, 250)
     })
   },
-  { deep: false }
+  { deep: false },
 )
-
 </script>
 
 <style lang="scss">

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -944,7 +944,7 @@
       },
       "reference": {
         "in_reply_to": "In reply to {username}",
-        "go_to_highlight": "Go to highlight"
+        "go_to_highlight": "Go to Highlight"
       },
       "reply": {
         "ariaLabel": "Comment Reply.  Author {username}",

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -942,6 +942,10 @@
         "show_reply": "Show Replies",
         "hide_reply": "Hide Replies"
       },
+      "reference": {
+        "in_reply_to": "In reply to {username}",
+        "go_to_highlight": "Go to highlight"
+      },
       "reply": {
         "ariaLabel": "Comment Reply.  Author {username}",
         "referenceButtonAria": "Jump to referenced comment",

--- a/client/src/pages/SubmissionReview.vue
+++ b/client/src/pages/SubmissionReview.vue
@@ -43,8 +43,7 @@
           />
           <q-separator class="page-seperator" />
           <div ref="scrollOverallComments"></div>
-          <submission-comment-section
-          />
+          <submission-comment-section />
           <div ref="scrollAddNewOverallComment"></div>
         </q-page-container>
       </q-layout>
@@ -96,7 +95,6 @@ function handleNewScroll() {
   setVerticalScrollPosition(scrollTarget, scrollValue.offsetTop, 250)
   scrollValue
 }
-
 </script>
 
 <style lang="sass" scoped>

--- a/client/src/pages/SubmissionReview.vue
+++ b/client/src/pages/SubmissionReview.vue
@@ -96,6 +96,7 @@ function handleNewScroll() {
   setVerticalScrollPosition(scrollTarget, scrollValue.offsetTop, 250)
   scrollValue
 }
+
 </script>
 
 <style lang="sass" scoped>


### PR DESCRIPTION
This adds a "reference" button to inline comment headers. This enables bidirectional scrolling behavior in that both the inline comments panel and the submission content area will scroll to make sure both the annotation and inline comment are visible whenever an inline comment's annotation or reference is clicked. Previously, this scrolling only happened within the inline comments panel when an annotation was clicked. Now, when an inline comment's reference is clicked, the corresponding annotation within the submission content area is scrolled to as well. 

![Screenshot of two inline comments with the newly added reference elements. They appears as the first item from the left within inline comment headers. Avatar images follow to their right.](https://github.com/MESH-Research/Pilcrow/assets/2668987/f274ff95-bacf-4e68-a599-cabf80dd049e)


Closes #1936 