### PR TITLE
fix: Fix Contrast Issue on Active Comment Menu

### DIFF
--- a/client/src/css/app.sass
+++ b/client/src/css/app.sass
@@ -256,7 +256,9 @@ body.body--dark
     .q-card.active
         border: 1px solid $highlight
 
-    button[data-cy="commentActions"],
+    button[data-cy="commentActions"]
+        color: #fff
+
     .q-btn-group .q-btn-item,
     .footer-text,
     span.q-breadcrumbs__el.q-link,


### PR DESCRIPTION
This pull request:

- Fixes a color contrast issue on the inline comment heading when a comment is highlighted

Closes #2056 