### PR TITLE
refactor: Use composable for notify messages

### DIFF
--- a/client/src/components/SubmissionTitle.vue
+++ b/client/src/components/SubmissionTitle.vue
@@ -70,7 +70,6 @@ import useVuelidate from "@vuelidate/core"
 
 const submission = inject("submission")
 const draft_title = ref("")
-const newPubV$ = useVuelidate(rules, draft_title)
 
 watchEffect(() => {
   if (submission.value) {
@@ -84,6 +83,7 @@ const rules = {
   required,
   maxLength: maxLength(512),
 }
+const newPubV$ = useVuelidate(rules, draft_title)
 
 const { newStatusMessage } = useFeedbackMessages({
   attrs: {

--- a/client/src/components/SubmissionTitle.vue
+++ b/client/src/components/SubmissionTitle.vue
@@ -60,7 +60,6 @@
 </template>
 
 <script setup>
-import { useQuasar } from "quasar"
 import { UPDATE_SUBMISSION_TITLE } from "src/graphql/mutations"
 import { useMutation } from "@vue/apollo-composable"
 import { ref, watchEffect, inject } from "vue"
@@ -71,6 +70,7 @@ import useVuelidate from "@vuelidate/core"
 
 const submission = inject("submission")
 const draft_title = ref("")
+const newPubV$ = useVuelidate(rules, draft_title)
 
 watchEffect(() => {
   if (submission.value) {
@@ -78,7 +78,6 @@ watchEffect(() => {
   }
 })
 
-const { notify } = useQuasar()
 const { t } = useI18n()
 
 const rules = {
@@ -92,7 +91,6 @@ const { newStatusMessage } = useFeedbackMessages({
   },
 })
 
-const newPubV$ = useVuelidate(rules, draft_title)
 function checkThatFormIsInvalid() {
   let failureMessage = false
 
@@ -133,14 +131,7 @@ async function saveTitle() {
       title: draft_title.value,
     })
   } catch (error) {
-    notify({
-      color: "negative",
-      message: t("submission.edit_title.unauthorized"),
-      icon: "error",
-      attrs: {
-        "data-cy": "edit_title_notify",
-      },
-    })
+    newStatusMessage("failure", t("submission.edit_title.unauthorized"))
   } finally {
     editing_title.value = false
     submitting_title_edit.value = false

--- a/client/src/components/atoms/EmailVerificationSendButton.vue
+++ b/client/src/components/atoms/EmailVerificationSendButton.vue
@@ -27,6 +27,7 @@ import { useMutation } from "@vue/apollo-composable"
 import { useQuasar } from "quasar"
 import { useGraphErrors } from "src/use/errors"
 import { useI18n } from "vue-i18n"
+import { useFeedbackMessages } from "src/use/guiElements"
 
 const $q = useQuasar()
 const status = ref(null)
@@ -41,9 +42,14 @@ const btnColor = computed(() => {
 })
 
 const { mutate: sendEmail } = useMutation(SEND_VERIFY_EMAIL)
-const { notify } = useQuasar()
 const { errorMessages, graphQLErrorCodes } = useGraphErrors()
 const { t } = useI18n()
+const { newStatusMessage } = useFeedbackMessages({
+  attrs: {
+    "data-cy": "email_verification_notify",
+    icon: "email"
+  },
+})
 
 async function send() {
   status.value = "loading"
@@ -51,29 +57,26 @@ async function send() {
     const result = await sendEmail()
     const email = result.data.sendEmailVerification.email
     status.value = "success"
-    notify({
-      color: "positive",
-      message: t("account.email_verify.send_success_notify", {
+    newStatusMessage(
+      "success",
+      t("account.email_verify.send_success_notify", {
         email,
       }),
-      icon: "email",
-      html: true,
-    })
+    )
   } catch (error) {
     const errorMessagesList = errorMessages(
       graphQLErrorCodes(error),
-      "account.failures"
+      "account.failures",
     )
     if (!errorMessagesList.length) {
       errorMessagesList.push(t("failures.UNKNOWN_ERROR"))
     }
-    notify({
-      color: "negative",
-      message: t("account.email_verify.send_failure_notify", {
+    newStatusMessage(
+      "failure",
+      t("account.email_verify.send_failure_notify", {
         errors: errorMessagesList.join(", "),
       }),
-      icon: "error",
-    })
+    )
     status.value = null
   }
 }

--- a/client/src/components/dialogs/ConfirmCommentDeletion.vue
+++ b/client/src/components/dialogs/ConfirmCommentDeletion.vue
@@ -36,13 +36,14 @@
 </template>
 
 <script setup>
-import { useDialogPluginComponent, useQuasar } from "quasar"
+import { useDialogPluginComponent } from "quasar"
 import { useMutation } from "@vue/apollo-composable"
 import {
   DELETE_INLINE_COMMENT,
   DELETE_OVERALL_COMMENT,
 } from "src/graphql/mutations"
 import { useI18n } from "vue-i18n"
+import { useFeedbackMessages } from "src/use/guiElements"
 
 const props = defineProps({
   comment: {
@@ -63,8 +64,12 @@ const mutation =
     ? DELETE_INLINE_COMMENT
     : DELETE_OVERALL_COMMENT
 const { mutate } = useMutation(mutation)
-const { notify } = useQuasar()
 const { t } = useI18n()
+const { newStatusMessage } = useFeedbackMessages({
+  attrs: {
+    "data-cy": "delete_comment_notify",
+  }
+})
 
 async function deleteComment() {
   try {
@@ -78,14 +83,7 @@ async function deleteComment() {
       },
     )
   } catch (error) {
-    notify({
-      color: "negative",
-      message: t("dialog.deleteComment.failure"),
-      icon: "error",
-      attrs: {
-        "data-cy": "delete_comment_notify",
-      },
-    })
+    newStatusMessage("failure", t("dialog.deleteComment.failure"))
   }
 }
 

--- a/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
+++ b/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
@@ -58,14 +58,14 @@
 </template>
 
 <script setup>
-import { useDialogPluginComponent, useQuasar } from "quasar"
+import { useDialogPluginComponent } from "quasar"
 import { useMutation } from "@vue/apollo-composable"
 import { UPDATE_SUBMISSION_STATUS } from "src/graphql/mutations"
 import { ref } from "vue"
 import { useI18n } from "vue-i18n"
+import { useFeedbackMessages } from "src/use/guiElements"
 
 const { t } = useI18n()
-const { notify } = useQuasar()
 
 defineEmits([...useDialogPluginComponent.emits])
 
@@ -122,6 +122,11 @@ const colors = {
 const comment = ref(null)
 
 const { mutate } = useMutation(UPDATE_SUBMISSION_STATUS)
+const { newStatusMessage } = useFeedbackMessages({
+  attrs: {
+    "data-cy": "change_status_notify",
+  }
+})
 
 async function updateStatus() {
   try {
@@ -130,23 +135,9 @@ async function updateStatus() {
       status: statuses[props.action],
       status_change_comment: comment.value,
     })
-    notify({
-      color: "positive",
-      message: t(`dialog.confirmStatusChange.statusChanged.${props.action}`),
-      icon: "done",
-      attrs: {
-        "data-cy": "change_status_notify",
-      },
-    })
+    newStatusMessage("success", t(`dialog.confirmStatusChange.statusChanged.${props.action}`))
   } catch (error) {
-    notify({
-      color: "negative",
-      message: t("dialog.confirmStatusChange.unauthorized"),
-      icon: "error",
-      attrs: {
-        "data-cy": "change_status_notify",
-      },
-    })
+    newStatusMessage("failure", t("dialog.confirmStatusChange.unauthorized"))
   }
 }
 </script>

--- a/client/src/components/dialogs/ReinviteUserDialog.vue
+++ b/client/src/components/dialogs/ReinviteUserDialog.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup>
-import { useDialogPluginComponent, useQuasar } from "quasar"
+import { useDialogPluginComponent } from "quasar"
 import { useMutation } from "@vue/apollo-composable"
 import {
   REINVITE_REVIEWER,
@@ -58,9 +58,14 @@ import {
 } from "src/graphql/mutations"
 import { computed, ref } from "vue"
 import { useI18n } from "vue-i18n"
+import { useFeedbackMessages } from "src/use/guiElements"
 
 const { t } = useI18n()
-const { notify } = useQuasar()
+const { newStatusMessage } = useFeedbackMessages({
+  attrs: {
+    "data-cy": "reinvite_notify",
+  },
+})
 
 defineEmits([...useDialogPluginComponent.emits])
 
@@ -99,28 +104,20 @@ async function reinviteUser() {
     await mutate({
       message: comment.value,
     })
-    notify({
-      color: "positive",
-      message: t(`dialog.reinviteUser.success`, {
+    newStatusMessage(
+      "success",
+      t(`dialog.reinviteUser.success`, {
         email: props.email,
         role: t(`role.${props.roleGroup}`, 1),
       }),
-      icon: "done",
-      attrs: {
-        "data-cy": "reinvite_notify",
-      },
-    })
+    )
   } catch (error) {
-    notify({
-      color: "negative",
-      message: t(`dialog.reinviteUser.failure`, {
+    newStatusMessage(
+      "failure",
+      t(`dialog.reinviteUser.failure`, {
         email: props.email,
       }),
-      icon: "error",
-      attrs: {
-        "data-cy": "reinvite_notify",
-      },
-    })
+    )
   }
 }
 </script>

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1149,7 +1149,8 @@
         "request_resubmission": "A resubmission is requested for this submission.",
         "open": "This submission is now under review.",
         "close": "This submission is closed for review.",
-        "accept_as_final": "This submission is accepted as final."
+        "accept_as_final": "This submission is accepted as final.",
+        "delete": "This submission is now deleted."
       }
     },
     "discardChanges": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1150,7 +1150,8 @@
         "open": "This submission is now under review.",
         "close": "This submission is closed for review.",
         "accept_as_final": "This submission is accepted as final.",
-        "delete": "This submission is now deleted."
+        "delete": "This submission is now deleted.",
+        "archive": "This submission is now archived."
       }
     },
     "discardChanges": {


### PR DESCRIPTION
This refactors usages of the `notify` library to use the `useFeedbackMessages` composable that's located in `guiElements.js`. This makes the presentation of these notifications consistent across the app.

Bonus: This also adds some missing submission status change messages for deletions and archives. 

Closes #1804 