### PR TITLE
fix: Move component attribute

### DIFF
--- a/client/src/components/forms/CommentEditor.vue
+++ b/client/src/components/forms/CommentEditor.vue
@@ -11,9 +11,9 @@
       </q-btn-group>
       <div class="comment-editor" @focus-editor="focusOnEditor">
         <editor-content
+          ref="focusEditor"
           data-cy="comment-editor"
           :editor="editor"
-          ref="focusEditor"
         />
       </div>
       <div v-if="commentType === 'InlineComment'" class="q-py-md">


### PR DESCRIPTION
This resolves a check annotation on GitHub for pull requests wherein it complains that the attribute "ref" should go before ":editor" in CommentEditor.vue.

![check-annotation](https://github.com/MESH-Research/Pilcrow/assets/2668987/e698d690-a8e3-4d2c-a29b-8fbd990c1add)
