### PR TITLE
feat: Submit Submission from Preview Page

### DIFF
--- a/client/src/components/SubmissionTableActions.vue
+++ b/client/src/components/SubmissionTableActions.vue
@@ -112,7 +112,7 @@
               data-cy="initially_submit"
               class="items-center"
               clickable
-              @click="confirmHandler('submit_for_review', submission.id)"
+              @click="confirmHandler('submit_for_review', submission)"
               >{{ $t("submission.action.submit_for_review") }}</q-item
             >
           </div>
@@ -130,7 +130,7 @@
               data-cy="accept_for_review"
               class="items-center"
               clickable
-              @click="confirmHandler('accept_for_review', submission.id)"
+              @click="confirmHandler('accept_for_review', submission)"
               >{{ $t("submission.action.accept_for_review") }}</q-item
             >
             <q-item
@@ -142,7 +142,7 @@
               data-cy="accept_as_final"
               class="items-center"
               clickable
-              @click="confirmHandler('accept_as_final', submission.id)"
+              @click="confirmHandler('accept_as_final', submission)"
               >{{ $t("submission.action.accept_as_final") }}</q-item
             >
             <q-item
@@ -153,7 +153,7 @@
               role="menuitem"
               class="items-center"
               clickable
-              @click="confirmHandler('request_resubmission', submission.id)"
+              @click="confirmHandler('request_resubmission', submission)"
               >{{ $t("submission.action.request_resubmission") }}</q-item
             >
             <q-item
@@ -165,7 +165,7 @@
               data-cy="reject"
               class="items-center"
               clickable
-              @click="confirmHandler('reject', submission.id)"
+              @click="confirmHandler('reject', submission)"
               >{{ $t("submission.action.reject") }}
             </q-item>
             <q-item
@@ -174,7 +174,7 @@
               data-cy="archive"
               class="items-center"
               clickable
-              @click="confirmHandler('archive', submission.id)"
+              @click="confirmHandler('archive', submission)"
               >{{ $t("submission.action.archive") }}
             </q-item>
             <q-item
@@ -186,7 +186,7 @@
               data-cy="delete"
               class="items-center"
               clickable
-              @click="confirmHandler('delete', submission.id)"
+              @click="confirmHandler('delete', submission)"
               >{{ $t("submission.action.delete") }}
             </q-item>
           </div>
@@ -197,7 +197,7 @@
             data-cy="open_review"
             class="items-center"
             clickable
-            @click="confirmHandler('open', submission.id)"
+            @click="confirmHandler('open', submission)"
             >{{ $t("submission.action.open") }}
           </q-item>
           <q-item
@@ -206,7 +206,7 @@
             data-cy="close_review"
             class="items-center"
             clickable
-            @click="confirmHandler('close', submission.id)"
+            @click="confirmHandler('close', submission)"
             >{{ $t("submission.action.close") }}
           </q-item>
         </q-menu>
@@ -289,9 +289,9 @@ function cannotAccessSubmission(submission) {
     submission.effective_role == "reviewer"
   )
 }
-async function confirmHandler(action, id) {
+async function confirmHandler(action, submission) {
   await new Promise((resolve) => {
-    dirtyDialog(action, id)
+    dirtyDialog(action, submission)
       .onOk(function () {
         resolve(true)
       })
@@ -303,12 +303,13 @@ async function confirmHandler(action, id) {
     return
   }
 }
-function dirtyDialog(action, id) {
+function dirtyDialog(action, submission) {
   return dialog({
     component: ConfirmStatusChangeDialog,
     componentProps: {
       action: action,
-      submissionId: id,
+      submissionId: submission.id,
+      currentStatus: submission.status,
     },
   })
 }

--- a/client/src/components/atoms/StatusChangeDropdown.vue
+++ b/client/src/components/atoms/StatusChangeDropdown.vue
@@ -9,14 +9,13 @@
   >
     <q-btn-group flat square class="column q-pa-sm" data-cy="decision_options">
       <q-btn
-        v-for="(state, index) in nextStates[submissionRef.status]"
-        :key="index"
-        :data-cy="stateButtons[state].dataCy"
-        :color="stateButtons[state].color"
-        :label="$t(`submission.action.${stateButtons[state].action}`)"
-        :class="stateButtons[state].class"
+        v-for="state in nextStates[submissionRef.status]"
+        :key="state"
+        v-bind="submissionStateButtons[state].attrs"
+        :label="$t(`submission.action.${submissionStateButtons[state].action}`)"
         @click="
-          stateButtons[state].action ? confirmHandler(stateButtons[state].action) : () => {}
+          submissionStateButtons[state].action &&
+            confirmHandler(submissionStateButtons[state].action)
         "
       ></q-btn>
     </q-btn-group>
@@ -25,7 +24,10 @@
 <script setup>
 import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
 import { useQuasar } from "quasar"
-import { useStatusChangeControls } from "src/use/guiElements.js"
+import {
+  useStatusChangeControls,
+  submissionStateButtons,
+} from "src/use/guiElements.js"
 import { toRef } from "vue"
 
 const { dialog } = useQuasar()
@@ -38,8 +40,11 @@ const props = defineProps({
 })
 
 const submissionRef = toRef(props, "submission")
-const { statusChangingDisabledByRole, statusChangingDisabledByState, stateButtons, nextStates } =
-  useStatusChangeControls(submissionRef)
+const {
+  statusChangingDisabledByRole,
+  statusChangingDisabledByState,
+  nextStates,
+} = useStatusChangeControls(submissionRef)
 
 async function confirmHandler(action) {
   await new Promise((resolve) => {

--- a/client/src/components/atoms/StatusChangeDropdown.vue
+++ b/client/src/components/atoms/StatusChangeDropdown.vue
@@ -7,20 +7,12 @@
     menu-self="top right"
     data-cy="status-dropdown"
   >
-    <q-btn v-if="nextStates.length == 0"> No options available </q-btn>
-    <q-btn-group
-      v-else
-      flat
-      square
-      class="column q-pa-sm"
-      data-cy="decision_options"
-    >
+    <q-btn-group flat square class="column q-pa-sm" data-cy="decision_options">
       <q-btn
         v-for="(state, index) in nextStates"
         :key="index"
-        :next-states
-        :data-cy="states[state].dataCy ?? ''"
-        :color="states[state].color ?? ''"
+        :data-cy="states[state].dataCy"
+        :color="states[state].color"
         :label="$t(`submission.action.${states[state].action}`)"
         :class="states[state].class"
         @click="
@@ -34,7 +26,7 @@
 import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
 import { useQuasar } from "quasar"
 import { useStatusChangeControls } from "src/use/guiElements.js"
-import { computed, ref } from "vue"
+import { computed, toRef } from "vue"
 
 const { dialog } = useQuasar()
 
@@ -45,7 +37,7 @@ const props = defineProps({
   },
 })
 
-const submissionRef = ref(props.submission)
+const submissionRef = toRef(props, "submission")
 const { statusChangingDisabledByRole, statusChangingDisabledByState, states } =
   useStatusChangeControls(submissionRef)
 

--- a/client/src/components/atoms/StatusChangeDropdown.vue
+++ b/client/src/components/atoms/StatusChangeDropdown.vue
@@ -11,12 +11,12 @@
       <q-btn
         v-for="(state, index) in nextStates[submissionRef.status]"
         :key="index"
-        :data-cy="states[state].dataCy"
-        :color="states[state].color"
-        :label="$t(`submission.action.${states[state].action}`)"
-        :class="states[state].class"
+        :data-cy="stateButtons[state].dataCy"
+        :color="stateButtons[state].color"
+        :label="$t(`submission.action.${stateButtons[state].action}`)"
+        :class="stateButtons[state].class"
         @click="
-          states[state].action ? confirmHandler(states[state].action) : () => {}
+          stateButtons[state].action ? confirmHandler(stateButtons[state].action) : () => {}
         "
       ></q-btn>
     </q-btn-group>
@@ -38,7 +38,7 @@ const props = defineProps({
 })
 
 const submissionRef = toRef(props, "submission")
-const { statusChangingDisabledByRole, statusChangingDisabledByState, states, nextStates } =
+const { statusChangingDisabledByRole, statusChangingDisabledByState, stateButtons, nextStates } =
   useStatusChangeControls(submissionRef)
 
 async function confirmHandler(action) {
@@ -61,6 +61,7 @@ function dirtyDialog(action) {
     componentProps: {
       action: action,
       submissionId: props.submission.id,
+      currentStatus: props.submission.status,
     },
   })
 }

--- a/client/src/components/atoms/StatusChangeDropdown.vue
+++ b/client/src/components/atoms/StatusChangeDropdown.vue
@@ -9,7 +9,7 @@
   >
     <q-btn-group flat square class="column q-pa-sm" data-cy="decision_options">
       <q-btn
-        v-for="(state, index) in nextStates"
+        v-for="(state, index) in nextStates[submissionRef.status]"
         :key="index"
         :data-cy="states[state].dataCy"
         :color="states[state].color"
@@ -26,7 +26,7 @@
 import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
 import { useQuasar } from "quasar"
 import { useStatusChangeControls } from "src/use/guiElements.js"
-import { computed, toRef } from "vue"
+import { toRef } from "vue"
 
 const { dialog } = useQuasar()
 
@@ -38,12 +38,8 @@ const props = defineProps({
 })
 
 const submissionRef = toRef(props, "submission")
-const { statusChangingDisabledByRole, statusChangingDisabledByState, states } =
+const { statusChangingDisabledByRole, statusChangingDisabledByState, states, nextStates } =
   useStatusChangeControls(submissionRef)
-
-const nextStates = computed(() => {
-  return states[`${submissionRef.value.status}`].nextStates
-})
 
 async function confirmHandler(action) {
   await new Promise((resolve) => {

--- a/client/src/components/atoms/StatusChangeDropdown.vue
+++ b/client/src/components/atoms/StatusChangeDropdown.vue
@@ -1,0 +1,79 @@
+<template>
+  <q-btn-dropdown
+    v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
+    :label="$t(`submission.toolbar.status_options`)"
+    flat
+    menu-anchor="bottom right"
+    menu-self="top right"
+    data-cy="status-dropdown"
+  >
+    <q-btn v-if="nextStates.length == 0"> No options available </q-btn>
+    <q-btn-group
+      v-else
+      flat
+      square
+      class="column q-pa-sm"
+      data-cy="decision_options"
+    >
+      <q-btn
+        v-for="(state, index) in nextStates"
+        :key="index"
+        :next-states
+        :data-cy="states[state].dataCy ?? ''"
+        :color="states[state].color ?? ''"
+        :label="$t(`submission.action.${states[state].action}`)"
+        :class="states[state].class"
+        @click="
+          states[state].action ? confirmHandler(states[state].action) : () => {}
+        "
+      ></q-btn>
+    </q-btn-group>
+  </q-btn-dropdown>
+</template>
+<script setup>
+import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
+import { useQuasar } from "quasar"
+import { useStatusChangeControls } from "src/use/guiElements.js"
+import { computed, ref } from "vue"
+
+const { dialog } = useQuasar()
+
+const props = defineProps({
+  submission: {
+    type: Object,
+    default: null,
+  },
+})
+
+const submissionRef = ref(props.submission)
+const { statusChangingDisabledByRole, statusChangingDisabledByState, states } =
+  useStatusChangeControls(submissionRef)
+
+const nextStates = computed(() => {
+  return states[`${submissionRef.value.status}`].nextStates
+})
+
+async function confirmHandler(action) {
+  await new Promise((resolve) => {
+    dirtyDialog(action)
+      .onOk(function () {
+        resolve(true)
+      })
+      .onCancel(function () {
+        resolve(false)
+      })
+  })
+  {
+    return false
+  }
+}
+function dirtyDialog(action) {
+  return dialog({
+    component: ConfirmStatusChangeDialog,
+    componentProps: {
+      action: action,
+      submissionId: props.submission.id,
+    },
+  })
+}
+</script>

--- a/client/src/components/atoms/SubmissionPreviewToolbar.vue
+++ b/client/src/components/atoms/SubmissionPreviewToolbar.vue
@@ -28,6 +28,7 @@
           </q-chip>
         </div>
       </q-toolbar-title>
+      <status-change-dropdown :submission="submission" />
       <q-btn
         color="primary"
         :to="{
@@ -40,6 +41,7 @@
   </q-header>
 </template>
 <script setup>
+import StatusChangeDropdown from "./StatusChangeDropdown.vue"
 const props = defineProps({
   submission: {
     type: Object,

--- a/client/src/components/atoms/SubmissionToolbar.vue
+++ b/client/src/components/atoms/SubmissionToolbar.vue
@@ -33,6 +33,8 @@
         </div>
       </q-toolbar-title>
 
+      <status-change-dropdown :submission="submission" />
+
       <q-btn-dropdown
         v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
         :label="$t(`submission.toolbar.status_options`)"
@@ -41,17 +43,21 @@
         menu-self="top right"
         data-cy="status-dropdown"
       >
-        <div v-if="submission.status == 'DRAFT'">
+        <q-btn-group
+          v-if="submission.status == 'DRAFT'"
+          flat
+          square
+          class="column q-pa-sm"
+        >
           <q-btn
             data-cy="initially_submit"
-            rounded
             color="positive"
             :label="$t(`submission.action.submit_for_review`)"
-            class="q-ml-md"
+            class=""
             @click="confirmHandler('submit_for_review')"
           >
           </q-btn>
-        </div>
+        </q-btn-group>
 
         <q-btn-group
           v-else-if="
@@ -83,8 +89,7 @@
             :label="$t(`submission.action.accept_as_final`)"
             class=""
             @click="confirmHandler('accept_as_final')"
-          >
-          </q-btn>
+          ></q-btn>
           <q-btn
             rounded
             :label="$t(`submission.action.request_resubmission`)"
@@ -240,6 +245,7 @@
 </template>
 <script setup>
 import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
+import StatusChangeDropdown from "./StatusChangeDropdown.vue"
 import { useQuasar } from "quasar"
 import {
   useSubmissionExport,

--- a/client/src/components/atoms/SubmissionToolbar.vue
+++ b/client/src/components/atoms/SubmissionToolbar.vue
@@ -35,155 +35,6 @@
 
       <status-change-dropdown :submission />
 
-      <q-btn-dropdown
-        v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"
-        :label="$t(`submission.toolbar.status_options`)"
-        flat
-        menu-anchor="bottom right"
-        menu-self="top right"
-        data-cy="status-dropdown"
-      >
-        <q-btn-group
-          v-if="submission.status == 'DRAFT'"
-          flat
-          square
-          class="column q-pa-sm"
-        >
-          <q-btn
-            data-cy="initially_submit"
-            color="positive"
-            :label="$t(`submission.action.submit_for_review`)"
-            class=""
-            @click="confirmHandler('submit_for_review')"
-          >
-          </q-btn>
-        </q-btn-group>
-
-        <q-btn-group
-          v-else-if="
-            submission.status != 'AWAITING_REVIEW' &&
-            submission.status != 'REJECTED' &&
-            submission.status != 'RESUBMISSION_REQUESTED' &&
-            submission.status != 'ACCEPTED_AS_FINAL' &&
-            submission.status != 'ARCHIVED'
-          "
-          flat
-          square
-          data-cy="decision_options"
-          class="column q-pa-sm"
-        >
-          <q-btn
-            v-if="submission.status == 'INITIALLY_SUBMITTED'"
-            data-cy="accept_for_review"
-            color="positive"
-            :label="$t(`submission.action.accept_for_review`)"
-            class=""
-            @click="confirmHandler('accept_for_review')"
-          >
-          </q-btn>
-          <q-btn
-            v-if="submission.status != 'INITIALLY_SUBMITTED'"
-            data-cy="accept_as_final"
-            rounded
-            color="positive"
-            :label="$t(`submission.action.accept_as_final`)"
-            class=""
-            @click="confirmHandler('accept_as_final')"
-          ></q-btn>
-          <q-btn
-            rounded
-            :label="$t(`submission.action.request_resubmission`)"
-            class="text-white request-resubmission"
-            color="dark-grey"
-            @click="confirmHandler('request_resubmission')"
-          >
-          </q-btn>
-          <q-btn
-            rounded
-            color="negative"
-            :label="$t(`submission.action.reject`)"
-            class=""
-            @click="confirmHandler('reject')"
-          >
-          </q-btn>
-          <q-btn
-            v-if="submission.status == 'UNDER_REVIEW'"
-            data-cy="close_for_review"
-            rounded
-            color="black"
-            :label="$t(`submission.action.close`)"
-            class=""
-            @click="confirmHandler('close')"
-          >
-          </q-btn>
-        </q-btn-group>
-
-        <q-btn-group
-          v-if="submission.status == 'AWAITING_REVIEW'"
-          flat
-          square
-          class="column q-pa-sm"
-        >
-          <q-btn
-            v-if="submission.status == 'AWAITING_REVIEW'"
-            data-cy="open_for_review"
-            rounded
-            color="black"
-            :label="$t(`submission.action.open`)"
-            class=""
-            @click="confirmHandler('open')"
-          >
-          </q-btn>
-        </q-btn-group>
-
-        <q-btn-group
-          v-if="submission.status == 'ACCEPTED_AS_FINAL'"
-          data-cy="decision_options"
-          flat
-          square
-          class="column q-pa-sm"
-        >
-          <q-btn
-            v-if="submission.status == 'ACCEPTED_AS_FINAL'"
-            data-cy="archive"
-            rounded
-            color="dark-grey"
-            :label="$t(`submission.action.archive`)"
-            class=""
-            @click="confirmHandler('archive')"
-          >
-          </q-btn>
-          <q-btn
-            v-if="submission.status == 'ACCEPTED_AS_FINAL'"
-            data-cy="delete"
-            rounded
-            color="negative"
-            :label="$t(`submission.action.delete`)"
-            class=""
-            @click="confirmHandler('delete')"
-          >
-          </q-btn>
-        </q-btn-group>
-
-        <q-btn-group
-          v-if="submission.status == 'ARCHIVED'"
-          data-cy="decision_options"
-          flat
-          square
-          class="column q-pa-sm"
-        >
-          <q-btn
-            v-if="submission.status == 'ARCHIVED'"
-            data-cy="delete"
-            rounded
-            color="negative"
-            :label="$t(`submission.action.delete`)"
-            class=""
-            @click="confirmHandler('delete')"
-          >
-          </q-btn>
-        </q-btn-group>
-      </q-btn-dropdown>
       <q-icon
         v-if="isDisabledByRole || isDisabledByState"
         data-cy="submission_export_btn"
@@ -244,16 +95,12 @@
   </q-header>
 </template>
 <script setup>
-import ConfirmStatusChangeDialog from "../dialogs/ConfirmStatusChangeDialog.vue"
 import StatusChangeDropdown from "./StatusChangeDropdown.vue"
-import { useQuasar } from "quasar"
 import {
   useSubmissionExport,
   useStatusChangeControls,
 } from "src/use/guiElements.js"
 import { ref } from "vue"
-
-const { dialog } = useQuasar()
 
 const props = defineProps({
   // Drawer status
@@ -274,7 +121,6 @@ const props = defineProps({
 const submissionRef = ref(props.submission)
 const { isDisabledByRole, isDisabledByState } =
   useSubmissionExport(submissionRef)
-const { statusChangingDisabledByRole, statusChangingDisabledByState } =
   useStatusChangeControls(submissionRef)
 const emit = defineEmits([
   "update:commentDrawerOpen",
@@ -285,28 +131,5 @@ function toggleCommentDrawer() {
 }
 function toggleAnnotationHighlights() {
   emit("update:highlightVisibility", !props.highlightVisibility)
-}
-async function confirmHandler(action) {
-  await new Promise((resolve) => {
-    dirtyDialog(action)
-      .onOk(function () {
-        resolve(true)
-      })
-      .onCancel(function () {
-        resolve(false)
-      })
-  })
-  {
-    return
-  }
-}
-function dirtyDialog(action) {
-  return dialog({
-    component: ConfirmStatusChangeDialog,
-    componentProps: {
-      action: action,
-      submissionId: props.submission.id,
-    },
-  })
 }
 </script>

--- a/client/src/components/atoms/SubmissionToolbar.vue
+++ b/client/src/components/atoms/SubmissionToolbar.vue
@@ -33,7 +33,7 @@
         </div>
       </q-toolbar-title>
 
-      <status-change-dropdown :submission="submission" />
+      <status-change-dropdown :submission />
 
       <q-btn-dropdown
         v-if="!statusChangingDisabledByRole && !statusChangingDisabledByState"

--- a/client/src/components/atoms/SubmissionViewToolbar.vue
+++ b/client/src/components/atoms/SubmissionViewToolbar.vue
@@ -28,10 +28,12 @@
           </q-chip>
         </div>
       </q-toolbar-title>
+      <status-change-dropdown :submission="submission" />
     </q-toolbar>
   </q-header>
 </template>
 <script setup>
+import StatusChangeDropdown from "./StatusChangeDropdown.vue"
 const props = defineProps({
   submission: {
     type: Object,

--- a/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
+++ b/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
@@ -100,7 +100,7 @@ const statuses = {
   accept_as_final: "ACCEPTED_AS_FINAL",
   close: "AWAITING_DECISION",
   archive: "ARCHIVED",
-  delete: "DELETED"
+  delete: "DELETED",
 }
 
 const icons = {
@@ -112,7 +112,7 @@ const icons = {
   close: "grading",
   accept_as_final: "done",
   archive: "archive",
-  delete: "delete"
+  delete: "delete",
 }
 
 const colors = {
@@ -124,7 +124,7 @@ const colors = {
   close: "black",
   accept_as_final: "positive",
   archive: "dark-grey",
-  delete: "negative"
+  delete: "negative",
 }
 const comment = ref(null)
 
@@ -132,7 +132,7 @@ const { mutate } = useMutation(UPDATE_SUBMISSION_STATUS)
 const { newStatusMessage } = useFeedbackMessages({
   attrs: {
     "data-cy": "change_status_notify",
-  }
+  },
 })
 const { push } = useRouter()
 
@@ -142,14 +142,18 @@ async function updateStatus() {
       id: String(props.submissionId),
       status: statuses[props.action],
       status_change_comment: comment.value,
+    }).then(() => {
+      if (props.currentStatus == "DRAFT") {
+        push({ path: `/submission/${props.submissionId}/view/` })
+      }
+      if (props.currentStatus == "INITIALLY_SUBMITTED") {
+        push({ path: `/submission/${props.submissionId}/review/` })
+      }
     })
-    if (props.currentStatus == 'DRAFT') {
-      push({ path: `/submission/${props.submissionId}/view/` })
-    }
-    if (props.currentStatus == 'INITIALLY_SUBMITTED') {
-      push({ path: `/submission/${props.submissionId}/review/` })
-    }
-    newStatusMessage("success", t(`dialog.confirmStatusChange.statusChanged.${props.action}`))
+    newStatusMessage(
+      "success",
+      t(`dialog.confirmStatusChange.statusChanged.${props.action}`),
+    )
   } catch (error) {
     newStatusMessage("failure", t("dialog.confirmStatusChange.unauthorized"))
   }

--- a/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
+++ b/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
@@ -14,6 +14,7 @@
             <i18n-t
               :keypath="`dialog.confirmStatusChange.body.${props.action}`"
               tag="span"
+              scope="global"
             >
             </i18n-t>
           </p>
@@ -26,6 +27,7 @@
             <i18n-t
               :keypath="`dialog.confirmStatusChange.comment`"
               tag="span"
+              scope="global"
             />
           </p>
         </div>
@@ -64,6 +66,7 @@ import { UPDATE_SUBMISSION_STATUS } from "src/graphql/mutations"
 import { ref } from "vue"
 import { useI18n } from "vue-i18n"
 import { useFeedbackMessages } from "src/use/guiElements"
+import { useRouter } from "vue-router"
 
 const { t } = useI18n()
 
@@ -79,6 +82,10 @@ const props = defineProps({
     default: null,
   },
   submissionId: {
+    type: String,
+    required: true,
+  },
+  currentStatus: {
     type: String,
     required: true,
   },
@@ -127,6 +134,7 @@ const { newStatusMessage } = useFeedbackMessages({
     "data-cy": "change_status_notify",
   }
 })
+const { push } = useRouter()
 
 async function updateStatus() {
   try {
@@ -135,6 +143,12 @@ async function updateStatus() {
       status: statuses[props.action],
       status_change_comment: comment.value,
     })
+    if (props.currentStatus == 'DRAFT') {
+      push({ path: `/submission/${props.submissionId}/view/` })
+    }
+    if (props.currentStatus == 'INITIALLY_SUBMITTED') {
+      push({ path: `/submission/${props.submissionId}/review/` })
+    }
     newStatusMessage("success", t(`dialog.confirmStatusChange.statusChanged.${props.action}`))
   } catch (error) {
     newStatusMessage("failure", t("dialog.confirmStatusChange.unauthorized"))

--- a/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
+++ b/client/src/components/dialogs/ConfirmStatusChangeDialog.vue
@@ -4,8 +4,8 @@
       <q-card-section class="row no-wrap">
         <div class="q-pa-sm q-pr-md column">
           <q-avatar
-            :icon="icons[props.action]"
-            :color="colors[props.action]"
+            :icon="state.icon"
+            :color="state.attrs.color"
             text-color="white"
           />
         </div>
@@ -63,9 +63,12 @@
 import { useDialogPluginComponent } from "quasar"
 import { useMutation } from "@vue/apollo-composable"
 import { UPDATE_SUBMISSION_STATUS } from "src/graphql/mutations"
-import { ref } from "vue"
+import { computed, ref } from "vue"
 import { useI18n } from "vue-i18n"
-import { useFeedbackMessages } from "src/use/guiElements"
+import {
+  useFeedbackMessages,
+  submissionStateButtons,
+} from "src/use/guiElements"
 import { useRouter } from "vue-router"
 
 const { t } = useI18n()
@@ -90,42 +93,19 @@ const props = defineProps({
     required: true,
   },
 })
+const state = computed(() => {
+  const match = Object.entries(submissionStateButtons).find(
+    ([, value]) => value.action === props.action,
+  )
+  if (match === undefined) {
+    return {}
+  }
+  return {
+    ...match[1],
+    status: match[0],
+  }
+})
 
-const statuses = {
-  submit_for_review: "INITIALLY_SUBMITTED",
-  accept_for_review: "AWAITING_REVIEW",
-  reject: "REJECTED",
-  request_resubmission: "RESUBMISSION_REQUESTED",
-  open: "UNDER_REVIEW",
-  accept_as_final: "ACCEPTED_AS_FINAL",
-  close: "AWAITING_DECISION",
-  archive: "ARCHIVED",
-  delete: "DELETED",
-}
-
-const icons = {
-  submit_for_review: "edit_document",
-  accept_for_review: "done",
-  reject: "do_not_disturb",
-  request_resubmission: "refresh",
-  open: "grading",
-  close: "grading",
-  accept_as_final: "done",
-  archive: "archive",
-  delete: "delete",
-}
-
-const colors = {
-  submit_for_review: "positive",
-  accept_for_review: "positive",
-  reject: "negative",
-  request_resubmission: "dark-grey",
-  open: "black",
-  close: "black",
-  accept_as_final: "positive",
-  archive: "dark-grey",
-  delete: "negative",
-}
 const comment = ref(null)
 
 const { mutate } = useMutation(UPDATE_SUBMISSION_STATUS)
@@ -140,7 +120,7 @@ async function updateStatus() {
   try {
     await mutate({
       id: String(props.submissionId),
-      status: statuses[props.action],
+      status: state.value.status,
       status_change_comment: comment.value,
     }).then(() => {
       if (props.currentStatus == "DRAFT") {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -643,6 +643,7 @@
       "unauthorized": "You are not authorized to edit this submission's title. Please contact your administrator."
     },
     "action": {
+      "no_status_options": "No Options Available",
       "preview": "Preview Submission",
       "view": "View Submission",
       "review": "Review Submission",

--- a/client/src/pages/SubmissionDraft.vue
+++ b/client/src/pages/SubmissionDraft.vue
@@ -152,6 +152,7 @@ function dirtyDialog(action) {
     componentProps: {
       action: action,
       submissionId: props.id,
+      currentStatus: submission.value.status,
     },
   })
 }

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -70,6 +70,107 @@ export function useFeedbackMessages(overrideDefaults = {}) {
   return { newMessage, newStatusMessage }
 }
 
+export const submissionStateButtons = {
+  DRAFT: {
+    action: null,
+    attrs: {
+      color: "",
+      class: "",
+      dataCy: "",
+    },
+  },
+  INITIALLY_SUBMITTED: {
+    action: "submit_for_review",
+    attrs: {
+      color: "positive",
+      class: "",
+      dataCy: "initially_submit",
+    },
+    icon: "edit_document",
+  },
+  AWAITING_REVIEW: {
+    action: "accept_for_review",
+    attrs: {
+      color: "positive",
+      class: "",
+      dataCy: "open_for_review",
+    },
+    icon: "done",
+  },
+  UNDER_REVIEW: {
+    action: "open",
+    attrs: {
+      color: "black",
+      class: "",
+      dataCy: "open_for_review",
+    },
+    icon: "grading",
+  },
+  AWAITING_DECISION: {
+    action: "close",
+    attrs: {
+      color: "black",
+      class: "",
+      dataCy: "close_for_review",
+    },
+    icon: "grading",
+  },
+  ACCEPTED_AS_FINAL: {
+    action: "accept_as_final",
+    attrs: {
+      color: "positive",
+      class: "",
+      dataCy: "accept_as_final",
+    },
+    icon: "done",
+  },
+  ARCHIVED: {
+    action: "archive",
+    attrs: {
+      color: "dark-grey",
+      class: "",
+      dataCy: "archive",
+    },
+    icon: "archive",
+  },
+  DELETED: {
+    action: "delete",
+    attrs: {
+      color: "negative",
+      class: "",
+      dataCy: "delete",
+    },
+    icon: "delete",
+  },
+  REJECTED: {
+    action: "reject",
+    attrs: {
+      color: "negative",
+      class: "",
+      dataCy: "",
+    },
+    icon: "do_not_disturb",
+  },
+  RESUBMISSION_REQUESTED: {
+    action: "request_resubmission",
+    attrs: {
+      color: "dark-grey",
+      class: "text-white request-resubmission",
+      dataCy: "",
+    },
+    icon: "refresh",
+  },
+  EXPIRED: {
+    action: null,
+    attrs: {
+      color: "",
+      class: "",
+      dataCy: "",
+    },
+    icon: "",
+  },
+}
+
 export function useStatusChangeControls(submission) {
   const { isReviewer } = useCurrentUser()
 
@@ -121,77 +222,7 @@ export function useStatusChangeControls(submission) {
     EXPIRED: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
   }
 
-  const stateButtons = {
-    DRAFT: {
-      action: null,
-      color: "",
-      class: "",
-      dataCy: "",
-    },
-    INITIALLY_SUBMITTED: {
-      action: "submit_for_review",
-      color: "positive",
-      class: "",
-      dataCy: "initially_submit",
-    },
-    AWAITING_REVIEW: {
-      action: "open",
-      color: "positive",
-      class: "",
-      dataCy: "open_for_review",
-    },
-    UNDER_REVIEW: {
-      action: "open",
-      color: "black",
-      class: "",
-      dataCy: "open_for_review",
-    },
-    AWAITING_DECISION: {
-      action: "close",
-      color: "black",
-      class: "",
-      dataCy: "close_for_review",
-    },
-    ACCEPTED_AS_FINAL: {
-      action: "accept_as_final",
-      color: "positive",
-      class: "",
-      dataCy: "accept_as_final",
-    },
-    ARCHIVED: {
-      action: "archive",
-      color: "dark-grey",
-      class: "",
-      dataCy: "archive",
-    },
-    DELETED: {
-      action: "delete",
-      color: "negative",
-      class: "",
-      dataCy: "delete",
-    },
-    REJECTED: {
-      action: "reject",
-      color: "negative",
-      class: "",
-      dataCy: "",
-    },
-    RESUBMISSION_REQUESTED: {
-      action: "request_resubmission",
-      color: "dark-grey",
-      class: "text-white request-resubmission",
-      dataCy: "",
-    },
-    EXPIRED: {
-      action: null,
-      color: "",
-      class: "",
-      dataCy: "",
-    },
-  }
-
   return {
-    stateButtons,
     nextStates,
     statusChangingDisabledByRole,
     statusChangingDisabledByState,

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -135,10 +135,10 @@ export function useStatusChangeControls(submission) {
       dataCy: "initially_submit",
     },
     AWAITING_REVIEW: {
-      action: "accept_for_review",
+      action: "open",
       color: "positive",
       class: "",
-      dataCy: "",
+      dataCy: "open_for_review",
     },
     UNDER_REVIEW: {
       action: "open",

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -93,6 +93,21 @@ export function useStatusChangeControls(submission) {
     return statusChangingDisabledStates.includes(submission.value.status)
   })
 
+  // const nextStates = {
+  //   "INITIALLY_SUBMITTED": [
+  //       "UNDER_REVIEW",
+  //       "ACCEPTED_AS_FINAL",
+  //       "RESUBMISSION_REQUESTED",
+  //       "REJECTED",
+  //     },
+  //   "UNDER_REVIEW",
+  //   "ACCEPTED_AS_FINAL",
+  //   "RESUBMISSION_REQUESTED",
+  //   "REJECTED",
+  //   "ARCHIVED",
+  //   "DELETED",
+  // ]
+
   const states = {
     DRAFT: {
       action: null,

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -93,7 +93,98 @@ export function useStatusChangeControls(submission) {
     return statusChangingDisabledStates.includes(submission.value.status)
   })
 
+  const states = {
+    DRAFT: {
+      action: null,
+      color: "",
+      class: "",
+      dataCy: "",
+      nextStates: ["INITIALLY_SUBMITTED"],
+    },
+    INITIALLY_SUBMITTED: {
+      action: "submit_for_review",
+      color: "positive",
+      class: "",
+      dataCy: "initially_submit",
+      nextStates: [
+        "UNDER_REVIEW",
+        "ACCEPTED_AS_FINAL",
+        "REJECTED",
+        "RESUBMISSION_REQUESTED",
+      ],
+    },
+    AWAITING_REVIEW: {
+      action: "accept_for_review",
+      color: "positive",
+      class: "",
+      dataCy: "",
+      nextStates: ["UNDER_REVIEW"],
+    },
+    UNDER_REVIEW: {
+      action: "open",
+      color: "",
+      class: "",
+      dataCy: "",
+      nextStates: [
+        "ACCEPTED_AS_FINAL",
+        "RESUBMISSION_REQUESTED",
+        "REJECTED",
+        "AWAITING_DECISION",
+      ],
+    },
+    AWAITING_DECISION: {
+      action: "close",
+      color: "black",
+      class: "",
+      dataCy: "close_for_review",
+      nextStates: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
+    },
+    ACCEPTED_AS_FINAL: {
+      action: "accept_as_final",
+      color: "positive",
+      class: "",
+      dataCy: "accept_as_final",
+      nextStates: ["ARCHIVED", "DELETED"],
+    },
+    ARCHIVED: {
+      action: "archive",
+      color: "dark-grey",
+      class: "",
+      dataCy: "archive",
+      nextStates: ["DELETED"],
+    },
+    DELETED: {
+      action: "delete",
+      color: "negative",
+      class: "",
+      dataCy: "delete",
+      nextStates: [],
+    },
+    REJECTED: {
+      action: "reject",
+      color: "negative",
+      class: "",
+      dataCy: "",
+      nextStates: ["ARCHIVED", "DELETED"],
+    },
+    RESUBMISSION_REQUESTED: {
+      action: "request_resubmission",
+      color: "dark-grey",
+      class: "text-white request-resubmission",
+      dataCy: "",
+      nextStates: ["ARCHIVED", "DELETED"],
+    },
+    EXPIRED: {
+      action: null,
+      color: "",
+      class: "",
+      dataCy: "",
+      nextStates: [],
+    },
+  }
+
   return {
+    states,
     statusChangingDisabledByRole,
     statusChangingDisabledByState,
   }

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -121,7 +121,7 @@ export function useStatusChangeControls(submission) {
     EXPIRED: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
   }
 
-  const states = {
+  const stateButtons = {
     DRAFT: {
       action: null,
       color: "",
@@ -191,7 +191,7 @@ export function useStatusChangeControls(submission) {
   }
 
   return {
-    states,
+    stateButtons,
     nextStates,
     statusChangingDisabledByRole,
     statusChangingDisabledByState,

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -142,9 +142,9 @@ export function useStatusChangeControls(submission) {
     },
     UNDER_REVIEW: {
       action: "open",
-      color: "",
+      color: "black",
       class: "",
-      dataCy: "",
+      dataCy: "open_for_review",
     },
     AWAITING_DECISION: {
       action: "close",

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -76,7 +76,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "",
       class: "",
-      dataCy: "",
+      "data-cy": "",
     },
   },
   INITIALLY_SUBMITTED: {
@@ -84,7 +84,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "positive",
       class: "",
-      dataCy: "initially_submit",
+      "data-cy": "initially_submit",
     },
     icon: "edit_document",
   },
@@ -93,7 +93,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "positive",
       class: "",
-      dataCy: "open_for_review",
+      "data-cy": "open_for_review",
     },
     icon: "done",
   },
@@ -102,7 +102,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "black",
       class: "",
-      dataCy: "open_for_review",
+      "data-y": "open_for_review",
     },
     icon: "grading",
   },
@@ -111,7 +111,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "black",
       class: "",
-      dataCy: "close_for_review",
+      "data-cy": "close_for_review",
     },
     icon: "grading",
   },
@@ -120,7 +120,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "positive",
       class: "",
-      dataCy: "accept_as_final",
+      "data-cy": "accept_as_final",
     },
     icon: "done",
   },
@@ -129,7 +129,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "dark-grey",
       class: "",
-      dataCy: "archive",
+      "data-cy": "archive",
     },
     icon: "archive",
   },
@@ -138,7 +138,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "negative",
       class: "",
-      dataCy: "delete",
+      "data-cy": "delete",
     },
     icon: "delete",
   },
@@ -147,7 +147,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "negative",
       class: "",
-      dataCy: "",
+      "data-cy": "",
     },
     icon: "do_not_disturb",
   },
@@ -156,7 +156,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "dark-grey",
       class: "text-white request-resubmission",
-      dataCy: "",
+      "data-cy": "",
     },
     icon: "refresh",
   },
@@ -165,7 +165,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "",
       class: "",
-      dataCy: "",
+      "data-cy": "",
     },
     icon: "",
   },

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -109,8 +109,8 @@ export function useStatusChangeControls(submission) {
       nextStates: [
         "UNDER_REVIEW",
         "ACCEPTED_AS_FINAL",
-        "REJECTED",
         "RESUBMISSION_REQUESTED",
+        "REJECTED",
       ],
     },
     AWAITING_REVIEW: {
@@ -179,7 +179,7 @@ export function useStatusChangeControls(submission) {
       color: "",
       class: "",
       dataCy: "",
-      nextStates: [],
+      nextStates: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
     },
   }
 

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -102,7 +102,7 @@ export const submissionStateButtons = {
     attrs: {
       color: "black",
       class: "",
-      "data-y": "open_for_review",
+      "data-cy": "open_for_review",
     },
     icon: "grading",
   },

--- a/client/src/use/guiElements.js
+++ b/client/src/use/guiElements.js
@@ -93,20 +93,33 @@ export function useStatusChangeControls(submission) {
     return statusChangingDisabledStates.includes(submission.value.status)
   })
 
-  // const nextStates = {
-  //   "INITIALLY_SUBMITTED": [
-  //       "UNDER_REVIEW",
-  //       "ACCEPTED_AS_FINAL",
-  //       "RESUBMISSION_REQUESTED",
-  //       "REJECTED",
-  //     },
-  //   "UNDER_REVIEW",
-  //   "ACCEPTED_AS_FINAL",
-  //   "RESUBMISSION_REQUESTED",
-  //   "REJECTED",
-  //   "ARCHIVED",
-  //   "DELETED",
-  // ]
+  const nextStates = {
+    DRAFT: ["INITIALLY_SUBMITTED"],
+    INITIALLY_SUBMITTED: [
+      "UNDER_REVIEW",
+      "ACCEPTED_AS_FINAL",
+      "RESUBMISSION_REQUESTED",
+      "REJECTED",
+    ],
+    AWAITING_REVIEW: ["UNDER_REVIEW"],
+    UNDER_REVIEW: [
+      "ACCEPTED_AS_FINAL",
+      "RESUBMISSION_REQUESTED",
+      "REJECTED",
+      "AWAITING_DECISION",
+    ],
+    AWAITING_DECISION: [
+      "ACCEPTED_AS_FINAL",
+      "RESUBMISSION_REQUESTED",
+      "REJECTED",
+    ],
+    ACCEPTED_AS_FINAL: ["ARCHIVED", "DELETED"],
+    RESUBMISSION_REQUESTED: ["ARCHIVED", "DELETED"],
+    REJECTED: ["ARCHIVED", "DELETED"],
+    ARCHIVED: ["DELETED"],
+    DELETED: [],
+    EXPIRED: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
+  }
 
   const states = {
     DRAFT: {
@@ -114,92 +127,72 @@ export function useStatusChangeControls(submission) {
       color: "",
       class: "",
       dataCy: "",
-      nextStates: ["INITIALLY_SUBMITTED"],
     },
     INITIALLY_SUBMITTED: {
       action: "submit_for_review",
       color: "positive",
       class: "",
       dataCy: "initially_submit",
-      nextStates: [
-        "UNDER_REVIEW",
-        "ACCEPTED_AS_FINAL",
-        "RESUBMISSION_REQUESTED",
-        "REJECTED",
-      ],
     },
     AWAITING_REVIEW: {
       action: "accept_for_review",
       color: "positive",
       class: "",
       dataCy: "",
-      nextStates: ["UNDER_REVIEW"],
     },
     UNDER_REVIEW: {
       action: "open",
       color: "",
       class: "",
       dataCy: "",
-      nextStates: [
-        "ACCEPTED_AS_FINAL",
-        "RESUBMISSION_REQUESTED",
-        "REJECTED",
-        "AWAITING_DECISION",
-      ],
     },
     AWAITING_DECISION: {
       action: "close",
       color: "black",
       class: "",
       dataCy: "close_for_review",
-      nextStates: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
     },
     ACCEPTED_AS_FINAL: {
       action: "accept_as_final",
       color: "positive",
       class: "",
       dataCy: "accept_as_final",
-      nextStates: ["ARCHIVED", "DELETED"],
     },
     ARCHIVED: {
       action: "archive",
       color: "dark-grey",
       class: "",
       dataCy: "archive",
-      nextStates: ["DELETED"],
     },
     DELETED: {
       action: "delete",
       color: "negative",
       class: "",
       dataCy: "delete",
-      nextStates: [],
     },
     REJECTED: {
       action: "reject",
       color: "negative",
       class: "",
       dataCy: "",
-      nextStates: ["ARCHIVED", "DELETED"],
     },
     RESUBMISSION_REQUESTED: {
       action: "request_resubmission",
       color: "dark-grey",
       class: "text-white request-resubmission",
       dataCy: "",
-      nextStates: ["ARCHIVED", "DELETED"],
     },
     EXPIRED: {
       action: null,
       color: "",
       class: "",
       dataCy: "",
-      nextStates: ["ACCEPTED_AS_FINAL", "RESUBMISSION_REQUESTED", "REJECTED"],
     },
   }
 
   return {
     states,
+    nextStates,
     statusChangingDisabledByRole,
     statusChangingDisabledByState,
   }

--- a/client/test/cypress/integration/notificationpopup.cy.js
+++ b/client/test/cypress/integration/notificationpopup.cy.js
@@ -16,7 +16,7 @@ describe("Notification Popup", () => {
   it("allows multiple notifications to be marked as read", () => {
     cy.task("resetDb")
     cy.login({ email: "applicationadministrator@meshresearch.net" })
-    cy.visit("/submission/108/review")
+    cy.visit("/submission/101/review")
     cy.interceptGQLOperation("UpdateSubmissionStatus")
     cy.dataCy("status-dropdown").click()
     cy.dataCy("open_for_review").click()

--- a/client/test/cypress/integration/submissionreview.cy.js
+++ b/client/test/cypress/integration/submissionreview.cy.js
@@ -206,9 +206,9 @@ describe("Submissions Review", () => {
     cy.visit("submission/101/review")
     cy.dataCy("submission_status").contains("Initially Submitted")
     cy.dataCy("status-dropdown").click()
-    cy.dataCy("accept_for_review").click()
+    cy.dataCy("open_for_review").click()
     cy.dataCy("dirtyYesChangeStatus").click()
-    cy.dataCy("submission_status").contains("Awaiting Review")
+    cy.dataCy("submission_status").contains("Under Review")
     cy.login({ email: "reviewer@meshresearch.net" })
     cy.visit("submission/101/review")
     cy.url().should("not.include", "/error403")
@@ -483,7 +483,7 @@ describe("Submissions Review", () => {
 
     // click to scroll
     cy.dataCy("view_overall_comments").click()
-    
+
     // check scroll position
     cy.dataCy("view_overall_comments").should((element) => {
       let scrollY = element[0].getBoundingClientRect().top
@@ -503,7 +503,7 @@ describe("Submissions Review", () => {
 
     // click to scroll
     cy.dataCy("new_overall_comment").click()
-    
+
     // check scroll position
     cy.dataCy("new_overall_comment").should((element) => {
       let scrollY = element[0].getBoundingClientRect().top


### PR DESCRIPTION
This pull request:

* Refactors status changing template logic to a new component `StatusChangeDropdown`
    * uses data-driven logic for improved reusability
* Simplifies submission acceptance process
    * Accepting for review is no longer necessary; only opening for review
* Adds the `StatusChangeDropdown` component to the preview, view, and review pages
* Adds a check for status changes to draft and initially submitted submissions so that the interface changes accordingly
    * Draft submissions are redirected from the preview page to the view page
    * Initially Submitted submissions are redirected from the view page to the review page
* Bonus: Adds scope attributes to `i18n` tags to prevent warnings about global scope

Closes #2078 