### PR TITLE
feat: Add notifications for inline and overall comments

### DIFF
--- a/backend/app/Events/InlineCommentAdded.php
+++ b/backend/app/Events/InlineCommentAdded.php
@@ -11,7 +11,9 @@ use Illuminate\Queue\SerializesModels;
 
 class InlineCommentAdded
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
 
     /**
      * @var \App\Models\InlineComment $inline_comment

--- a/backend/app/Events/InlineCommentAdded.php
+++ b/backend/app/Events/InlineCommentAdded.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\InlineComment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class InlineCommentAdded
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var \App\Models\InlineComment $inline_comment
+     */
+    public $inline_comment;
+
+    /**
+     * @param \App\Models\InlineComment $inline_comment
+     */
+    public function __construct(InlineComment $inline_comment)
+    {
+        $this->inline_comment = $inline_comment;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/backend/app/Events/InlineCommentReplyAdded.php
+++ b/backend/app/Events/InlineCommentReplyAdded.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\InlineComment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class InlineCommentReplyAdded
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * @var \App\Models\InlineComment $inline_comment
+     */
+    public $inline_comment;
+
+    /**
+     * @param \App\Models\InlineComment $inline_comment
+     */
+    public function __construct(InlineComment $inline_comment)
+    {
+        $this->inline_comment = $inline_comment;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/backend/app/Events/OverallCommentAdded.php
+++ b/backend/app/Events/OverallCommentAdded.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\OverallComment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OverallCommentAdded
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * @var \App\Models\OverallComment $overall_comment
+     */
+    public $overall_comment;
+
+    /**
+     * @param \App\Models\OverallComment $overall_comment
+     */
+    public function __construct(OverallComment $overall_comment)
+    {
+        $this->overall_comment = $overall_comment;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/backend/app/Events/OverallCommentReplyAdded.php
+++ b/backend/app/Events/OverallCommentReplyAdded.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\OverallComment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OverallCommentReplyAdded
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * @var \App\Models\OverallComment $overall_comment
+     */
+    public $overall_comment;
+
+    /**
+     * @param \App\Models\OverallComment $overall_comment
+     */
+    public function __construct(OverallComment $overall_comment)
+    {
+        $this->overall_comment = $overall_comment;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/backend/app/Listeners/NotifyUsersAboutInlineComment.php
+++ b/backend/app/Listeners/NotifyUsersAboutInlineComment.php
@@ -9,7 +9,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
 
-class NotifyUsersAboutNewInlineComment extends Notification implements ShouldQueue
+class NotifyUsersAboutInlineComment extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/backend/app/Listeners/NotifyUsersAboutInlineCommentReply.php
+++ b/backend/app/Listeners/NotifyUsersAboutInlineCommentReply.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\InlineCommentReplyAdded as EventsInlineCommentReplyAdded;
+use App\Notifications\InlineCommentReplyAdded;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+
+class NotifyUsersAboutInlineCommentReply extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\InlineCommentReplyAdded $event
+     * @return void
+     */
+    public function handle(EventsInlineCommentReplyAdded $event): void
+    {
+        $submission = $event->inline_comment->submission;
+        $submitters = $submission->submitters()->get();
+        $parent_commentor = $event->inline_comment->parent->createdBy()->get();
+        $commentors = $event->inline_comment->parent->commentors()->get();
+        $review_coordinators = $submission->reviewCoordinators()->get();
+        $notification_data = [
+            'submission' => [
+                'id' => $submission->id,
+                'title' => $submission->title,
+            ],
+            'commentor' => [
+                'display_label' => $event->inline_comment->createdBy->displayLabel,
+            ],
+            'type' => 'submission.inline_comment_reply.added',
+        ];
+        $recipients = $submitters
+            ->merge($commentors)
+            ->merge($parent_commentor)
+            ->merge($review_coordinators)
+            ->unique()
+            ->filter(function ($user) use ($event) {
+                return $user->id !== $event->inline_comment->createdBy->id;
+            });
+
+        Notification::send($recipients, new InlineCommentReplyAdded($notification_data));
+    }
+}

--- a/backend/app/Listeners/NotifyUsersAboutNewInlineComment.php
+++ b/backend/app/Listeners/NotifyUsersAboutNewInlineComment.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\InlineCommentAdded as EventsInlineCommentAdded;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+use App\Notifications\InlineCommentAdded;
+
+class NotifyUsersAboutNewInlineComment extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Handle the event.
+     */
+    public function handle(EventsInlineCommentAdded $event): void
+    {
+        $submission = $event->inline_comment->submission;
+        $submitters = $submission->submitters;
+        $review_coordinators = $submission->review_coordinators;
+        $notification_data = [
+            'submission' => [
+                'id' => $submission->id,
+                'title' => $submission->title,
+            ],
+            'commentor' => [
+                'display_label' => $event->inline_comment->createdBy->displayLabel,
+            ],
+            'type' => 'submission.inline_comment.added',
+        ];
+
+        Notification::send($submitters, new InlineCommentAdded($notification_data));
+        Notification::send($review_coordinators, new InlineCommentAdded($notification_data));
+    }
+}

--- a/backend/app/Listeners/NotifyUsersAboutNewInlineComment.php
+++ b/backend/app/Listeners/NotifyUsersAboutNewInlineComment.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace App\Listeners;
 
 use App\Events\InlineCommentAdded as EventsInlineCommentAdded;
+use App\Notifications\InlineCommentAdded;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
-use App\Notifications\InlineCommentAdded;
 
 class NotifyUsersAboutNewInlineComment extends Notification implements ShouldQueue
 {
@@ -15,6 +15,9 @@ class NotifyUsersAboutNewInlineComment extends Notification implements ShouldQue
 
     /**
      * Handle the event.
+     *
+     * @param \App\Events\EventsInlineCommentAdded $event
+     * @return void
      */
     public function handle(EventsInlineCommentAdded $event): void
     {

--- a/backend/app/Listeners/NotifyUsersAboutOverallComment.php
+++ b/backend/app/Listeners/NotifyUsersAboutOverallComment.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\OverallCommentAdded as EventsOverallCommentAdded;
+use App\Notifications\OverallCommentAdded;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+
+class NotifyUsersAboutOverallComment extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\EventsOverallCommentAdded $event
+     * @return void
+     */
+    public function handle(EventsOverallCommentAdded $event): void
+    {
+        $submission = $event->overall_comment->submission;
+        $submitters = $submission->submitters;
+        $review_coordinators = $submission->review_coordinators;
+        $notification_data = [
+            'submission' => [
+                'id' => $submission->id,
+                'title' => $submission->title,
+            ],
+            'commentor' => [
+                'display_label' => $event->overall_comment->createdBy->displayLabel,
+            ],
+            'type' => 'submission.overall_comment.added',
+        ];
+
+        Notification::send($submitters, new OverallCommentAdded($notification_data));
+        Notification::send($review_coordinators, new OverallCommentAdded($notification_data));
+    }
+}

--- a/backend/app/Listeners/NotifyUsersAboutOverallCommentReply.php
+++ b/backend/app/Listeners/NotifyUsersAboutOverallCommentReply.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\OverallCommentReplyAdded as EventsOverallCommentReplyAdded;
+use App\Notifications\OverallCommentReplyAdded;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+
+class NotifyUsersAboutOverallCommentReply extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\OverallCommentReplyAdded $event
+     * @return void
+     */
+    public function handle(EventsOverallCommentReplyAdded $event): void
+    {
+        $submission = $event->overall_comment->submission;
+        $submitters = $submission->submitters()->get();
+        $parent_commentor = $event->overall_comment->parent->createdBy()->get();
+        $commentors = $event->overall_comment->parent->commentors()->get();
+        $review_coordinators = $submission->reviewCoordinators()->get();
+        $notification_data = [
+            'submission' => [
+                'id' => $submission->id,
+                'title' => $submission->title,
+            ],
+            'commentor' => [
+                'display_label' => $event->overall_comment->createdBy->displayLabel,
+            ],
+            'type' => 'submission.overall_comment_reply.added',
+        ];
+        $recipients = $submitters
+            ->merge($commentors)
+            ->merge($parent_commentor)
+            ->merge($review_coordinators)
+            ->unique()
+            ->filter(function ($user) use ($event) {
+                return $user->id !== $event->overall_comment->createdBy->id;
+            });
+
+        Notification::send($recipients, new OverallCommentReplyAdded($notification_data));
+    }
+}

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -90,10 +90,9 @@ class InlineComment extends BaseModel
      */
     public function commentors(): HasManyThrough
     {
-      // Get the parent inline comment
         $parentComment = $this->parent_id ? $this->parent : $this;
 
-      // Get all users who have replied to the parent inline comment
+        // Get all users who have replied to the parent inline comment
         return $this->hasManyThrough(
             User::class,
             InlineComment::class,

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Events\InlineCommentAdded;
 use App\Http\Traits\CreatedUpdatedBy;
 use App\Models\Traits\ReadStatus;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -37,6 +38,18 @@ class InlineComment extends BaseModel
         'from',
         'to',
     ];
+
+    /**
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+        static::created(function ($inlineComment) {
+            InlineCommentAdded::dispatch($inlineComment);
+        });
+    }
+
 
     /**
      * The submission that owns the inline comment

--- a/backend/app/Notifications/InlineCommentAdded.php
+++ b/backend/app/Notifications/InlineCommentAdded.php
@@ -18,6 +18,9 @@ class InlineCommentAdded extends Notification implements ShouldQueue
 
     /**
      * Create a new notification instance.
+     *
+     * @param array $inline_comment
+     * @return void
      */
     public function __construct($inline_comment)
     {
@@ -40,7 +43,7 @@ class InlineCommentAdded extends Notification implements ShouldQueue
      *
      * @return array<string, mixed>
      */
-    public function toArray(object $notifiable): array
+    public function toArray(): array
     {
         return [
             'submission' => [

--- a/backend/app/Notifications/InlineCommentAdded.php
+++ b/backend/app/Notifications/InlineCommentAdded.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class InlineCommentAdded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct($inline_comment)
+    {
+        $this->data = $inline_comment;
+        $this->after_commit = true;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'submission' => [
+                'id' => $this->data['submission']['id'],
+                'title' => $this->data['submission']['title'],
+            ],
+            'commentor' => [
+                'display_label' => $this->data['commentor']['display_label'],
+            ],
+            'type' => $this->data['type'],
+        ];
+    }
+}

--- a/backend/app/Notifications/InlineCommentReplyAdded.php
+++ b/backend/app/Notifications/InlineCommentReplyAdded.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class InlineCommentReplyAdded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param array $inline_comment
+     */
+    public function __construct($inline_comment)
+    {
+        $this->data = $inline_comment;
+        $this->after_commit = true;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'submission' => [
+                'id' => $this->data['submission']['id'],
+                'title' => $this->data['submission']['title'],
+            ],
+            'commentor' => [
+                'display_label' => $this->data['commentor']['display_label'],
+            ],
+            'type' => $this->data['type'],
+        ];
+    }
+}

--- a/backend/app/Notifications/OverallCommentAdded.php
+++ b/backend/app/Notifications/OverallCommentAdded.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class OverallCommentAdded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param array $overall_comment
+     * @return void
+     */
+    public function __construct($overall_comment)
+    {
+        $this->data = $overall_comment;
+        $this->after_commit = true;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'submission' => [
+                'id' => $this->data['submission']['id'],
+                'title' => $this->data['submission']['title'],
+            ],
+            'commentor' => [
+                'display_label' => $this->data['commentor']['display_label'],
+            ],
+            'type' => $this->data['type'],
+        ];
+    }
+}

--- a/backend/app/Notifications/OverallCommentReplyAdded.php
+++ b/backend/app/Notifications/OverallCommentReplyAdded.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class OverallCommentReplyAdded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param array $overall_comment
+     */
+    public function __construct($overall_comment)
+    {
+        $this->data = $overall_comment;
+        $this->after_commit = true;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'submission' => [
+                'id' => $this->data['submission']['id'],
+                'title' => $this->data['submission']['title'],
+            ],
+            'commentor' => [
+                'display_label' => $this->data['commentor']['display_label'],
+            ],
+            'type' => $this->data['type'],
+        ];
+    }
+}

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Events\OverallCommentAdded;
+use App\Events\OverallCommentReplyAdded;
 use App\Events\InlineCommentAdded;
 use App\Events\InlineCommentReplyAdded;
 use App\Events\ReviewCoordinatorInvitationAccepted;
@@ -15,6 +17,8 @@ use App\Listeners\NotifyUsersAboutAcceptedReviewCoordinatorInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewerInvitation;
 use App\Listeners\NotifyUsersAboutInlineComment;
 use App\Listeners\NotifyUsersAboutInlineCommentReply;
+use App\Listeners\NotifyUsersAboutOverallComment;
+use App\Listeners\NotifyUsersAboutOverallCommentReply;
 use App\Listeners\NotifyUsersAboutUpdatedSubmissionStatus;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -56,6 +60,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         InlineCommentReplyAdded::class => [
             NotifyUsersAboutInlineCommentReply::class,
+        ],
+        OverallCommentAdded::class => [
+            NotifyUsersAboutOverallComment::class,
+        ],
+        OverallCommentReplyAdded::class => [
+            NotifyUsersAboutOverallCommentReply::class,
         ],
     ];
 

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -13,7 +13,7 @@ use App\Listeners\NotifyReviewCoordinatorAboutInvitation;
 use App\Listeners\NotifyReviewerAboutInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewCoordinatorInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewerInvitation;
-use App\Listeners\NotifyUsersAboutNewInlineComment;
+use App\Listeners\NotifyUsersAboutInlineComment;
 use App\Listeners\NotifyUsersAboutInlineCommentReply;
 use App\Listeners\NotifyUsersAboutUpdatedSubmissionStatus;
 use Illuminate\Auth\Events\Registered;
@@ -52,7 +52,7 @@ class EventServiceProvider extends ServiceProvider
             'SocialiteProviders\Orcid\OrcidExtendSocialite@handle'
         ],
         InlineCommentAdded::class => [
-            NotifyUsersAboutNewInlineComment::class,
+            NotifyUsersAboutInlineComment::class,
         ],
         InlineCommentReplyAdded::class => [
             NotifyUsersAboutInlineCommentReply::class,

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Events\InlineCommentAdded;
+use App\Events\InlineCommentReplyAdded;
 use App\Events\ReviewCoordinatorInvitationAccepted;
 use App\Events\ReviewCoordinatorInvited;
 use App\Events\ReviewerInvited;
@@ -13,6 +14,7 @@ use App\Listeners\NotifyReviewerAboutInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewCoordinatorInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewerInvitation;
 use App\Listeners\NotifyUsersAboutNewInlineComment;
+use App\Listeners\NotifyUsersAboutInlineCommentReply;
 use App\Listeners\NotifyUsersAboutUpdatedSubmissionStatus;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -51,6 +53,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         InlineCommentAdded::class => [
             NotifyUsersAboutNewInlineComment::class,
+        ],
+        InlineCommentReplyAdded::class => [
+            NotifyUsersAboutInlineCommentReply::class,
         ],
     ];
 

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Events\InlineCommentAdded;
 use App\Events\ReviewCoordinatorInvitationAccepted;
 use App\Events\ReviewCoordinatorInvited;
 use App\Events\ReviewerInvited;
@@ -11,6 +12,7 @@ use App\Listeners\NotifyReviewCoordinatorAboutInvitation;
 use App\Listeners\NotifyReviewerAboutInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewCoordinatorInvitation;
 use App\Listeners\NotifyUsersAboutAcceptedReviewerInvitation;
+use App\Listeners\NotifyUsersAboutNewInlineComment;
 use App\Listeners\NotifyUsersAboutUpdatedSubmissionStatus;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -46,6 +48,9 @@ class EventServiceProvider extends ServiceProvider
         SocialiteWasCalled::class => [
             'SocialiteProviders\Google\GoogleExtendSocialite@handle',
             'SocialiteProviders\Orcid\OrcidExtendSocialite@handle'
+        ],
+        InlineCommentAdded::class => [
+            NotifyUsersAboutNewInlineComment::class,
         ],
     ];
 

--- a/backend/graphql/notification.graphql
+++ b/backend/graphql/notification.graphql
@@ -27,6 +27,7 @@ type NotificationData {
     body: String
     action: String
     url: String
+    commentor: User
     invitee: User
     inviter: User
     submission: Submission

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -6,9 +6,11 @@
     </testsuite>
     <testsuite name="Feature">
       <directory suffix="Test.php">./tests/Feature</directory>
+      <directory suffix="Test.php">./tests/Feature/Notifications</directory>
     </testsuite>
     <testsuite name="Api">
       <directory suffix="Test.php">./tests/Api</directory>
+      <directory suffix="Test.php">./tests/Api/Notifications</directory>
     </testsuite>
   </testsuites>
   <coverage/>

--- a/backend/tests/Api/Notifications/SubmissionStatusUpdatesTest.php
+++ b/backend/tests/Api/Notifications/SubmissionStatusUpdatesTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Api;
+namespace Tests\Api\Notifications;
 
 use App\Models\Publication;
 use App\Models\Submission;
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\ApiTestCase;
 
-class NotificationTest extends ApiTestCase
+class SubmissionStatusUpdatesTest extends ApiTestCase
 {
     use RefreshDatabase;
 

--- a/backend/tests/Api/SubmissionCommentTest.php
+++ b/backend/tests/Api/SubmissionCommentTest.php
@@ -5,93 +5,19 @@ namespace Tests\Api;
 
 use App\Models\InlineComment;
 use App\Models\OverallComment;
-use App\Models\StyleCriteria;
 use App\Models\Submission;
-use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Str;
 use Tests\ApiTestCase;
+use Tests\TestFactory;
 
 class SubmissionCommentTest extends ApiTestCase
 {
     use WithFaker;
     use RefreshDatabase;
-
-    /**
-     * @param int $status (default: Submission::UNDER_REVIEW)
-     * @return Submission
-     */
-    private function createSubmission($status = Submission::UNDER_REVIEW)
-    {
-        $user = User::factory()->create();
-
-        return Submission::factory()
-            ->hasAttached($user, [], 'submitters')
-            ->create(['status' => $status]);
-    }
-
-    /**
-     * @param int $id
-     * @return StyleCriteria
-     */
-    private function createStyleCriteria($id)
-    {
-        $criteria = StyleCriteria::factory()
-            ->create([
-                'name' => 'PHPUnit Criteria',
-                'publication_id' => $id,
-                'description' => 'This is a test style criteria created by PHPUnit',
-                'icon' => 'php',
-            ]);
-
-        return $criteria;
-    }
-
-    /**
-     * @param int $count
-     * @param User|null $user (optional)
-     * @return Submission
-     */
-    private function createSubmissionWithInlineComment($count = 1, $user = null)
-    {
-        if ($user === null) {
-            $user = User::factory()->create();
-        }
-        $submission = $this->createSubmission();
-        $style_criteria = $this->createStyleCriteria($submission->publication->id);
-        InlineComment::factory()->count($count)->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $user->id,
-            'updated_by' => $user->id,
-            'style_criteria' => [$style_criteria],
-        ]);
-
-        return $submission;
-    }
-
-    /**
-     * @param int $count
-     * @param User|null $user (optional)
-     * @return Submission
-     */
-    private function createSubmissionWithOverallComment($count = 1, $user = null)
-    {
-        if ($user === null) {
-            $user = User::factory()->create();
-        }
-        $submission = $this->createSubmission();
-        OverallComment::factory()->count($count)->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an overall comment created by PHPUnit.',
-            'created_by' => $user->id,
-            'updated_by' => $user->id,
-        ]);
-
-        return $submission;
-    }
+    use TestFactory;
 
     public function testRetrieveInlineComments()
     {

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -236,4 +236,59 @@ class NotificationTest extends TestCase
         $this->assertEquals(1, $reviewer->notifications->count());
         $this->assertEquals(1, $review_coordinator->notifications->count());
     }
+
+    /**
+     * @return void
+     */
+    public function testUsersReceiveNotificationsForInlineComments()
+    {
+        $submission = $this->createSubmissionWithInlineComment(4);
+        $comment = $submission->inlineComments->first();
+        $comment2 = $submission->inlineComments->splice(2, 1)->first();
+        $reviewer1 = User::factory()->create();
+        $reviewer2 = User::factory()->create();
+        $reviewer3 = User::factory()->create();
+        $submission->reviewers()->attach([$reviewer1->id, $reviewer2->id, $reviewer3->id]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer1->id,
+            'updated_by' => $reviewer1->id,
+            'style_criteria' => [],
+            'parent_id' => $comment->id,
+            'reply_to_id' => $comment->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer2->id,
+            'updated_by' => $reviewer2->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $comment2->id,
+        ]);
+        $c6 = InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer3->id,
+            'updated_by' => $reviewer3->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $comment2->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer2->id,
+            'updated_by' => $reviewer2->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $c6->id,
+        ]);
+
+        $comments = $submission->inlineCommentsWithReplies;
+        $data = $comments->splice(2, 1)->first()->commentors->unique()->toArray();
+
+        print_r($data);
+    }
 }

--- a/backend/tests/Feature/Notifications/InlineCommentsTest.php
+++ b/backend/tests/Feature/Notifications/InlineCommentsTest.php
@@ -12,56 +12,147 @@ class InlineCommentsTest extends TestCase
 {
     use TestFactory;
 
+    private function createSubmissionWithInlineCommentThread()
+    {
+        $submission = $this->createSubmissionWithAllRoles();
+
+        // Create comment participants
+        $commentor = User::factory()->create();
+        $commentor_reply = User::factory()->create();
+        $commentor_reply_to_reply = User::factory()->create();
+        $commentor_elsewhere = User::factory()->create();
+
+        // Assign comment participants as submission reviewers
+        $submission->reviewers()->attach([
+            $commentor->id,
+            $commentor_reply->id,
+            $commentor_reply_to_reply->id,
+            $commentor_elsewhere->id,
+        ]);
+
+        // Make comments
+        $comment_parent = InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $commentor->id,
+            'updated_by' => $commentor->id,
+            'style_criteria' => [],
+            'parent_id' => null,
+            'reply_to_id' => null,
+        ]);
+        $comment_reply = InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $commentor_reply->id,
+            'updated_by' => $commentor_reply->id,
+            'style_criteria' => [],
+            'parent_id' => $comment_parent->id,
+            'reply_to_id' => $comment_parent->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $commentor_reply_to_reply->id,
+            'updated_by' => $commentor_reply_to_reply->id,
+            'style_criteria' => [],
+            'parent_id' => $comment_parent->id,
+            'reply_to_id' => $comment_reply->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $commentor_elsewhere->id,
+            'updated_by' => $commentor_elsewhere->id,
+            'style_criteria' => [],
+            'parent_id' => null,
+            'reply_to_id' => null,
+        ]);
+
+        return $submission;
+    }
+
     /**
      * @return void
      */
-    public function testUsersReceiveNotificationsForInlineComments()
+    public function testUsersReceiveNotificationsForNewInlineComments()
     {
-        $submission = $this->createSubmissionWithInlineComment(4);
-        $comment = $submission->inlineComments->first();
-        $comment2 = $submission->inlineComments->splice(1, 1)->first();
-        $reviewer1 = User::factory()->create();
-        $reviewer2 = User::factory()->create();
-        $reviewer3 = User::factory()->create();
-        $submission->reviewers()->attach([$reviewer1->id, $reviewer2->id, $reviewer3->id]);
-        InlineComment::factory()->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $reviewer1->id,
-            'updated_by' => $reviewer1->id,
-            'style_criteria' => [],
-            'parent_id' => $comment->id,
-            'reply_to_id' => $comment->id,
-        ]);
-        InlineComment::factory()->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $reviewer2->id,
-            'updated_by' => $reviewer2->id,
-            'style_criteria' => [],
-            'parent_id' => $comment2->id,
-            'reply_to_id' => $comment2->id,
-        ]);
-        $c6 = InlineComment::factory()->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $reviewer3->id,
-            'updated_by' => $reviewer3->id,
-            'style_criteria' => [],
-            'parent_id' => $comment2->id,
-            'reply_to_id' => $comment2->id,
-        ]);
-        InlineComment::factory()->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $reviewer2->id,
-            'updated_by' => $reviewer2->id,
-            'style_criteria' => [],
-            'parent_id' => $comment2->id,
-            'reply_to_id' => $c6->id,
-        ]);
-
-        $comments = $submission->inlineCommentsWithReplies;
-        $data = $comments->splice(2, 1)->first()->commentors->unique()->toArray();
+        $submission = $this->createSubmissionWithInlineCommentThread();
+        $comments = $submission->inlineCommentsWithReplies();
+        $this->assertEquals(4, $comments->count());
+        $submission->submitters()->first()->notifications->map(function ($notification, int $key) use ($submission) {
+            switch ($key) {
+                case 0:
+                    $this->assertInlineComment($notification, $submission);
+                    break;
+                case 1:
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+                case 2:
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+                case 3:
+                    $this->assertInlineComment($notification, $submission);
+                    break;
+            }
+        });
+        $submission->reviewers()->first()->notifications->map(function ($notification, int $key) use ($submission) {
+            switch ($key) {
+                case 0: // Reply to inline comment
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+                case 1: // Reply to reply of inline comment
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+            }
+        });
+        $submission->reviewCoordinators()->first()->notifications->map(function ($notification, int $key) use ($submission) {
+            switch ($key) {
+                case 0:
+                    $this->assertInlineComment($notification, $submission);
+                    break;
+                case 1:
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+                case 2:
+                    $this->assertInlineCommentReply($notification, $submission);
+                    break;
+                case 3:
+                    $this->assertInlineComment($notification, $submission);
+                    break;
+            }
+        });
     }
+
+    /**
+     * @return void
+     */
+    private function assertInlineComment($notification, $submission)
+    {
+        try {
+            $this->assertEquals("App\Notifications\InlineCommentAdded", $notification->type);
+            $this->assertEquals($notification->data['type'], 'submission.inline_comment.added');
+            $this->assertEquals($notification->data['submission']['id'], $submission->id);
+        } catch (\Exception $e) {
+            print_r(User::where('id', $notification->notifiable_id)->first()->toArray());
+            print_r('Should be an inline comment');
+            print_r($notification->toArray());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function assertInlineCommentReply($notification, $submission)
+    {
+        try {
+            $this->assertEquals("App\Notifications\InlineCommentReplyAdded", $notification->type);
+            $this->assertEquals($notification->data['type'], 'submission.inline_comment_reply.added');
+            $this->assertEquals($notification->data['submission']['id'], $submission->id);
+        } catch (\Exception $e) {
+            print_r(User::where('id', $notification->notifiable_id)->first()->toArray());
+            print_r('Should be a reply');
+            print_r($notification->toArray());
+        }
+    }
+
 }

--- a/backend/tests/Feature/Notifications/InlineCommentsTest.php
+++ b/backend/tests/Feature/Notifications/InlineCommentsTest.php
@@ -31,6 +31,15 @@ class InlineCommentsTest extends TestCase
         ]);
 
         // Make comments
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $commentor_elsewhere->id,
+            'updated_by' => $commentor_elsewhere->id,
+            'style_criteria' => [],
+            'parent_id' => null,
+            'reply_to_id' => null,
+        ]);
         $comment_parent = InlineComment::factory()->create([
             'submission_id' => $submission->id,
             'content' => 'This is some content for an inline comment created by PHPUnit.',
@@ -58,15 +67,6 @@ class InlineCommentsTest extends TestCase
             'parent_id' => $comment_parent->id,
             'reply_to_id' => $comment_reply->id,
         ]);
-        InlineComment::factory()->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $commentor_elsewhere->id,
-            'updated_by' => $commentor_elsewhere->id,
-            'style_criteria' => [],
-            'parent_id' => null,
-            'reply_to_id' => null,
-        ]);
 
         return $submission;
     }
@@ -91,17 +91,17 @@ class InlineCommentsTest extends TestCase
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer1));
 
         // Inline Commentor
-        $reviewer2 = $submission->reviewers()->get()->slice(1,1)->first();
+        $reviewer2 = $submission->reviewers()->get()->slice(1, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer2));
         $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($reviewer2));
 
         // Inline Comment Replier
-        $reviewer3 = $submission->reviewers()->get()->slice(2,1)->first();
+        $reviewer3 = $submission->reviewers()->get()->slice(2, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer3));
         $this->assertEquals(1, $this->getInlineCommentReplyNotificationCount($reviewer3));
 
         // Inline Comment Reply Replier
-        $reviewer4 = $submission->reviewers()->get()->slice(3,1)->first();
+        $reviewer4 = $submission->reviewers()->get()->slice(3, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer4));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer4));
 
@@ -118,6 +118,7 @@ class InlineCommentsTest extends TestCase
     private function getInlineCommentNotificationCount($user)
     {
         $type = 'App\Notifications\InlineCommentAdded';
+
         return $user->notifications()->where('type', $type)->get()->count();
     }
 
@@ -128,7 +129,7 @@ class InlineCommentsTest extends TestCase
     private function getInlineCommentReplyNotificationCount($user)
     {
         $type = 'App\Notifications\InlineCommentReplyAdded';
+
         return $user->notifications()->where('type', $type)->get()->count();
     }
-
 }

--- a/backend/tests/Feature/Notifications/InlineCommentsTest.php
+++ b/backend/tests/Feature/Notifications/InlineCommentsTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\InlineComment;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\TestFactory;
+
+class InlineCommentsTest extends TestCase
+{
+    use TestFactory;
+
+    /**
+     * @return void
+     */
+    public function testUsersReceiveNotificationsForInlineComments()
+    {
+        $submission = $this->createSubmissionWithInlineComment(4);
+        $comment = $submission->inlineComments->first();
+        $comment2 = $submission->inlineComments->splice(1, 1)->first();
+        $reviewer1 = User::factory()->create();
+        $reviewer2 = User::factory()->create();
+        $reviewer3 = User::factory()->create();
+        $submission->reviewers()->attach([$reviewer1->id, $reviewer2->id, $reviewer3->id]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer1->id,
+            'updated_by' => $reviewer1->id,
+            'style_criteria' => [],
+            'parent_id' => $comment->id,
+            'reply_to_id' => $comment->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer2->id,
+            'updated_by' => $reviewer2->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $comment2->id,
+        ]);
+        $c6 = InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer3->id,
+            'updated_by' => $reviewer3->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $comment2->id,
+        ]);
+        InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $reviewer2->id,
+            'updated_by' => $reviewer2->id,
+            'style_criteria' => [],
+            'parent_id' => $comment2->id,
+            'reply_to_id' => $c6->id,
+        ]);
+
+        $comments = $submission->inlineCommentsWithReplies;
+        $data = $comments->splice(2, 1)->first()->commentors->unique()->toArray();
+    }
+}

--- a/backend/tests/Feature/Notifications/InlineCommentsTest.php
+++ b/backend/tests/Feature/Notifications/InlineCommentsTest.php
@@ -81,40 +81,58 @@ class InlineCommentsTest extends TestCase
         $this->assertEquals(4, $comments->count());
 
         // Submitter
-        // Gets all notifications
+        // Gets all 4 notifications
         $submitter = $submission->submitters()->first();
         $this->assertEquals(2, $this->getInlineCommentNotificationCount($submitter));
         $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($submitter));
 
         // Uninvolved First Reviewer
-        // Gets no notifications
+        // Gets 0 notifications
         $reviewer1 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer1));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer1));
 
         // Inline Commentor
-        // Gets notifications for all replies
+        // Gets 2 notifications for all replies
         $reviewer2 = $submission->reviewers()->get()->slice(1, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer2));
         $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($reviewer2));
 
         // Inline Comment Replier
-        // Gets notification for reply to reply
+        // Gets 1 notification for reply to reply
         $reviewer3 = $submission->reviewers()->get()->slice(2, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer3));
         $this->assertEquals(1, $this->getInlineCommentReplyNotificationCount($reviewer3));
 
         // Inline Comment Reply Replier
-        // Gets no notifications
+        // Gets 0 notifications
         $reviewer4 = $submission->reviewers()->get()->slice(3, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer4));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer4));
 
         // Separate Inline Commentor
-        // Gets no notifications
+        // Gets 0 notifications
         $reviewer5 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer5));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer5));
+
+        // Coordinator
+        // Gets all 4 notifications
+        $coordinator = $submission->reviewCoordinators()->first();
+        $this->assertEquals(2, $this->getInlineCommentNotificationCount($coordinator));
+        $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($coordinator));
+
+        // Editor
+        // Gets 0 notifications
+        $editor = $submission->publication->editors()->first();
+        $this->assertEquals(0, $this->getInlineCommentNotificationCount($editor));
+        $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($editor));
+
+        // Publication Admins
+        // Gets 0 notifications
+        $admin = $submission->publication->publicationAdmins()->first();
+        $this->assertEquals(0, $this->getInlineCommentNotificationCount($admin));
+        $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($admin));
     }
 
     /**

--- a/backend/tests/Feature/Notifications/InlineCommentsTest.php
+++ b/backend/tests/Feature/Notifications/InlineCommentsTest.php
@@ -81,31 +81,37 @@ class InlineCommentsTest extends TestCase
         $this->assertEquals(4, $comments->count());
 
         // Submitter
+        // Gets all notifications
         $submitter = $submission->submitters()->first();
         $this->assertEquals(2, $this->getInlineCommentNotificationCount($submitter));
         $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($submitter));
 
         // Uninvolved First Reviewer
+        // Gets no notifications
         $reviewer1 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer1));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer1));
 
         // Inline Commentor
+        // Gets notifications for all replies
         $reviewer2 = $submission->reviewers()->get()->slice(1, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer2));
         $this->assertEquals(2, $this->getInlineCommentReplyNotificationCount($reviewer2));
 
         // Inline Comment Replier
+        // Gets notification for reply to reply
         $reviewer3 = $submission->reviewers()->get()->slice(2, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer3));
         $this->assertEquals(1, $this->getInlineCommentReplyNotificationCount($reviewer3));
 
         // Inline Comment Reply Replier
+        // Gets no notifications
         $reviewer4 = $submission->reviewers()->get()->slice(3, 1)->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer4));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer4));
 
         // Separate Inline Commentor
+        // Gets no notifications
         $reviewer5 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getInlineCommentNotificationCount($reviewer5));
         $this->assertEquals(0, $this->getInlineCommentReplyNotificationCount($reviewer5));

--- a/backend/tests/Feature/Notifications/InvitationsTest.php
+++ b/backend/tests/Feature/Notifications/InvitationsTest.php
@@ -31,12 +31,12 @@ class InvitationsTest extends TestCase
         $invite = SubmissionInvitation::create([
             'submission_id' => $submission->id,
             'role_id' => Role::REVIEWER_ROLE_ID,
-            'email' => 'bob@msu.edu',
+            'email' => 'bob1@msu.edu',
         ]);
         $invite->inviteReviewer();
         $details = [
             'name' => '',
-            'username' => 'bob',
+            'username' => 'bob1',
             'password' => 'rLT2ovkZkMby5UpwiQkFBeS9',
         ];
         $invite->acceptInvite($details);
@@ -62,12 +62,12 @@ class InvitationsTest extends TestCase
         $invite = SubmissionInvitation::create([
             'submission_id' => $submission->id,
             'role_id' => Role::REVIEW_COORDINATOR_ROLE_ID,
-            'email' => 'bob@msu.edu',
+            'email' => 'bob2@msu.edu',
         ]);
         $invite->inviteReviewCoordinator();
         $details = [
             'name' => '',
-            'username' => 'bob',
+            'username' => 'bob2',
             'password' => 'aYUB1IYUadd38fl9mxAVv2',
         ];
         $invite->acceptInvite($details);

--- a/backend/tests/Feature/Notifications/InvitationsTest.php
+++ b/backend/tests/Feature/Notifications/InvitationsTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Role;
+use App\Models\Submission;
+use App\Models\SubmissionInvitation;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\TestFactory;
+
+class InvitationsTest extends TestCase
+{
+    use TestFactory;
+
+    /**
+     * @return void
+     */
+    public function testSubmissionUsersReceiveNotificationsUponAcceptedReviewerInvitations()
+    {
+        $this->beAppAdmin();
+        $submitter = User::factory()->create();
+        $reviewer = User::factory()->create();
+        $review_coordinator = User::factory()->create();
+        $submission = Submission::factory()
+            ->hasAttached($submitter, [], 'submitters')
+            ->hasAttached($reviewer, [], 'reviewers')
+            ->hasAttached($review_coordinator, [], 'reviewCoordinators')
+            ->create();
+        $invite = SubmissionInvitation::create([
+            'submission_id' => $submission->id,
+            'role_id' => Role::REVIEWER_ROLE_ID,
+            'email' => 'bob@msu.edu',
+        ]);
+        $invite->inviteReviewer();
+        $details = [
+            'name' => '',
+            'username' => 'bob',
+            'password' => 'rLT2ovkZkMby5UpwiQkFBeS9',
+        ];
+        $invite->acceptInvite($details);
+        $this->assertEquals(1, $submitter->notifications->count());
+        $this->assertEquals(1, $reviewer->notifications->count());
+        $this->assertEquals(1, $review_coordinator->notifications->count());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSubmissionUsersReceiveNotificationsUponAcceptedReviewCoordinatorInvitations()
+    {
+        $this->beAppAdmin();
+        $submitter = User::factory()->create();
+        $reviewer = User::factory()->create();
+        $review_coordinator = User::factory()->create();
+        $submission = Submission::factory()
+            ->hasAttached($submitter, [], 'submitters')
+            ->hasAttached($reviewer, [], 'reviewers')
+            ->hasAttached($review_coordinator, [], 'reviewCoordinators')
+            ->create();
+        $invite = SubmissionInvitation::create([
+            'submission_id' => $submission->id,
+            'role_id' => Role::REVIEW_COORDINATOR_ROLE_ID,
+            'email' => 'bob@msu.edu',
+        ]);
+        $invite->inviteReviewCoordinator();
+        $details = [
+            'name' => '',
+            'username' => 'bob',
+            'password' => 'aYUB1IYUadd38fl9mxAVv2',
+        ];
+        $invite->acceptInvite($details);
+        $this->assertEquals(1, $submitter->notifications->count());
+        $this->assertEquals(1, $reviewer->notifications->count());
+        $this->assertEquals(1, $review_coordinator->notifications->count());
+    }
+}

--- a/backend/tests/Feature/Notifications/OverallCommentsTest.php
+++ b/backend/tests/Feature/Notifications/OverallCommentsTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\OverallComment;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\TestFactory;
+
+class OverallCommentsTest extends TestCase
+{
+    use TestFactory;
+
+    private function createSubmissionWithOverallCommentThread()
+    {
+        $submission = $this->createSubmissionWithAllRoles();
+
+        // Create comment participants
+        $commentor = User::factory()->create();
+        $commentor_reply = User::factory()->create();
+        $commentor_reply_to_reply = User::factory()->create();
+        $commentor_elsewhere = User::factory()->create();
+
+        // Assign comment participants as submission reviewers
+        $submission->reviewers()->attach([
+            $commentor->id,
+            $commentor_reply->id,
+            $commentor_reply_to_reply->id,
+            $commentor_elsewhere->id,
+        ]);
+
+        // Make comments
+        OverallComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an overall comment created by PHPUnit.',
+            'created_by' => $commentor_elsewhere->id,
+            'updated_by' => $commentor_elsewhere->id,
+            'parent_id' => null,
+            'reply_to_id' => null,
+        ]);
+        $comment_parent = OverallComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an overall comment created by PHPUnit.',
+            'created_by' => $commentor->id,
+            'updated_by' => $commentor->id,
+            'parent_id' => null,
+            'reply_to_id' => null,
+        ]);
+        $comment_reply = OverallComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an overall comment reply created by PHPUnit.',
+            'created_by' => $commentor_reply->id,
+            'updated_by' => $commentor_reply->id,
+            'parent_id' => $comment_parent->id,
+            'reply_to_id' => $comment_parent->id,
+        ]);
+        OverallComment::factory()->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an overall comment reply to a reply created by PHPUnit.',
+            'created_by' => $commentor_reply_to_reply->id,
+            'updated_by' => $commentor_reply_to_reply->id,
+            'parent_id' => $comment_parent->id,
+            'reply_to_id' => $comment_reply->id,
+        ]);
+
+        return $submission;
+    }
+
+    /**
+     * @return void
+     */
+    public function testUsersReceiveNotificationsForNewOverallComments()
+    {
+        $submission = $this->createSubmissionWithOverallCommentThread();
+        $comments = $submission->overallCommentsWithReplies();
+        $this->assertEquals(4, $comments->count());
+
+        // Submitter
+        // Gets all notifications
+        $submitter = $submission->submitters()->first();
+        $this->assertEquals(2, $this->getOverallCommentNotificationCount($submitter));
+        $this->assertEquals(2, $this->getOverallCommentReplyNotificationCount($submitter));
+
+        // Uninvolved First Reviewer
+        // Gets no notifications
+        $reviewer1 = $submission->reviewers()->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer1));
+        $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer1));
+
+        // overall Commentor
+        // Gets notifications for all replies
+        $reviewer2 = $submission->reviewers()->get()->slice(1, 1)->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer2));
+        $this->assertEquals(2, $this->getOverallCommentReplyNotificationCount($reviewer2));
+
+        // overall Comment Replier
+        // Gets notification for reply to reply
+        $reviewer3 = $submission->reviewers()->get()->slice(2, 1)->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer3));
+        $this->assertEquals(1, $this->getOverallCommentReplyNotificationCount($reviewer3));
+
+        // overall Comment Reply Replier
+        // Gets no notifications
+        $reviewer4 = $submission->reviewers()->get()->slice(3, 1)->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer4));
+        $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer4));
+
+        // Separate overall Commentor
+        // Gets no notifications
+        $reviewer5 = $submission->reviewers()->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer5));
+        $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer5));
+    }
+
+    /**
+     * @param User $user
+     * @return int
+     */
+    private function getOverallCommentNotificationCount($user)
+    {
+        $type = 'App\Notifications\OverallCommentAdded';
+
+        return $user->notifications()->where('type', $type)->get()->count();
+    }
+
+    /**
+     * @param User $user
+     * @return int
+     */
+    private function getOverallCommentReplyNotificationCount($user)
+    {
+        $type = 'App\Notifications\OverallCommentReplyAdded';
+
+        return $user->notifications()->where('type', $type)->get()->count();
+    }
+}

--- a/backend/tests/Feature/Notifications/OverallCommentsTest.php
+++ b/backend/tests/Feature/Notifications/OverallCommentsTest.php
@@ -77,40 +77,58 @@ class OverallCommentsTest extends TestCase
         $this->assertEquals(4, $comments->count());
 
         // Submitter
-        // Gets all notifications
+        // Gets all 4 notifications
         $submitter = $submission->submitters()->first();
         $this->assertEquals(2, $this->getOverallCommentNotificationCount($submitter));
         $this->assertEquals(2, $this->getOverallCommentReplyNotificationCount($submitter));
 
         // Uninvolved First Reviewer
-        // Gets no notifications
+        // Gets 0 notifications
         $reviewer1 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer1));
         $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer1));
 
-        // overall Commentor
-        // Gets notifications for all replies
+        // Overall Commentor
+        // Gets 2 notifications for all replies
         $reviewer2 = $submission->reviewers()->get()->slice(1, 1)->first();
         $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer2));
         $this->assertEquals(2, $this->getOverallCommentReplyNotificationCount($reviewer2));
 
-        // overall Comment Replier
-        // Gets notification for reply to reply
+        // Overall Comment Replier
+        // Gets 1 notification for reply to reply
         $reviewer3 = $submission->reviewers()->get()->slice(2, 1)->first();
         $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer3));
         $this->assertEquals(1, $this->getOverallCommentReplyNotificationCount($reviewer3));
 
-        // overall Comment Reply Replier
-        // Gets no notifications
+        // Overall Comment Reply Replier
+        // Gets 0 notifications
         $reviewer4 = $submission->reviewers()->get()->slice(3, 1)->first();
         $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer4));
         $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer4));
 
         // Separate overall Commentor
-        // Gets no notifications
+        // Gets 0 notifications
         $reviewer5 = $submission->reviewers()->first();
         $this->assertEquals(0, $this->getOverallCommentNotificationCount($reviewer5));
         $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($reviewer5));
+
+        // Coordinator
+        // Gets all 4 notifications
+        $coordinator = $submission->reviewCoordinators()->first();
+        $this->assertEquals(2, $this->getOverallCommentNotificationCount($coordinator));
+        $this->assertEquals(2, $this->getOverallCommentReplyNotificationCount($coordinator));
+
+        // Editor
+        // Gets 0 notifications
+        $editor = $submission->publication->editors()->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($editor));
+        $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($editor));
+
+        // Publication Admins
+        // Gets 0 notifications
+        $admin = $submission->publication->publicationAdmins()->first();
+        $this->assertEquals(0, $this->getOverallCommentNotificationCount($admin));
+        $this->assertEquals(0, $this->getOverallCommentReplyNotificationCount($admin));
     }
 
     /**

--- a/backend/tests/Feature/SubmissionCommentTest.php
+++ b/backend/tests/Feature/SubmissionCommentTest.php
@@ -3,85 +3,16 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use App\Models\InlineComment;
-use App\Models\OverallComment;
-use App\Models\StyleCriteria;
-use App\Models\Submission;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Tests\TestFactory;
 
 class SubmissionCommentTest extends TestCase
 {
     use RefreshDatabase;
-
-    /**
-     * @return Submission
-     */
-    private function createSubmission()
-    {
-        $user = User::factory()->create();
-
-        return Submission::factory()
-            ->hasAttached($user, [], 'submitters')
-            ->create();
-    }
-
-    /**
-     * @param int $id
-     * @return StyleCriteria
-     */
-    private function createStyleCriteria($id)
-    {
-        $criteria = StyleCriteria::factory()
-            ->create([
-                'name' => 'PHPUnit Criteria',
-                'publication_id' => $id,
-                'description' => 'This is a test style criteria created by PHPUnit',
-                'icon' => 'php',
-            ]);
-
-        return $criteria;
-    }
-
-    /**
-     * @param int $count
-     * @return Submission
-     */
-    private function createSubmissionWithInlineComment($count = 1)
-    {
-        $user = User::factory()->create();
-        $submission = $this->createSubmission();
-        $style_criteria = $this->createStyleCriteria($submission->publication->id);
-        InlineComment::factory()->count($count)->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an inline comment created by PHPUnit.',
-            'created_by' => $user->id,
-            'updated_by' => $user->id,
-            'style_criteria' => [$style_criteria->toArray()],
-        ]);
-
-        return $submission;
-    }
-
-    /**
-     * @param int $count
-     * @return Submission
-     */
-    private function createSubmissionWithOverallComment($count = 1)
-    {
-        $user = User::factory()->create();
-        $submission = $this->createSubmission();
-        OverallComment::factory()->count($count)->create([
-            'submission_id' => $submission->id,
-            'content' => 'This is some content for an overall comment created by PHPUnit.',
-            'created_by' => $user->id,
-            'updated_by' => $user->id,
-        ]);
-
-        return $submission;
-    }
+    use TestFactory;
 
     public function testInlineCommentsAreNotRetrievedForASubmissionThatHasNone()
     {

--- a/backend/tests/TestFactory.php
+++ b/backend/tests/TestFactory.php
@@ -104,14 +104,15 @@ trait TestFactory
             $users->push(
                 User::factory()->create([
                     'username' => $this->faker->unique()->userName,
-                    'email' => $this->faker->unique()->safeEmail
+                    'email' => $this->faker->unique()->safeEmail,
                 ])
             );
         }
-        $submission->reviewers()->attach([$users->slice(0,1)->first()->id]);
-        $submission->reviewCoordinators()->attach([$users->slice(1,1)->first()->id]);
-        $submission->publication->editors()->attach([$users->slice(2,1)->first()->id]);
-        $submission->publication->publicationAdmins()->attach([$users->slice(3,1)->first()->id]);
+        $submission->reviewers()->attach([$users->slice(0, 1)->first()->id]);
+        $submission->reviewCoordinators()->attach([$users->slice(1, 1)->first()->id]);
+        $submission->publication->editors()->attach([$users->slice(2, 1)->first()->id]);
+        $submission->publication->publicationAdmins()->attach([$users->slice(3, 1)->first()->id]);
+
         return $submission;
     }
 }

--- a/backend/tests/TestFactory.php
+++ b/backend/tests/TestFactory.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Models\InlineComment;
+use App\Models\OverallComment;
+use App\Models\StyleCriteria;
+use App\Models\Submission;
+use App\Models\User;
+
+trait TestFactory
+{
+    /**
+     * @param int $status (default: Submission::UNDER_REVIEW)
+     * @return Submission
+     */
+    protected function createSubmission($status = Submission::UNDER_REVIEW)
+    {
+        $user = User::factory()->create();
+
+        return Submission::factory()
+            ->hasAttached($user, [], 'submitters')
+            ->create(['status' => $status]);
+    }
+
+    /**
+     * @param int $id
+     * @return StyleCriteria
+     */
+    protected function createStyleCriteria($id)
+    {
+        $criteria = StyleCriteria::factory()
+            ->create([
+                'name' => 'PHPUnit Criteria',
+                'publication_id' => $id,
+                'description' => 'This is a test style criteria created by PHPUnit',
+                'icon' => 'php',
+            ]);
+
+        return $criteria;
+    }
+
+    /**
+     * @param int $count
+     * @param User|null $user (optional)
+     * @return Submission
+     */
+    protected function createSubmissionWithInlineComment($count = 1, $user = null)
+    {
+        if ($user === null) {
+            $user = User::factory()->create();
+        }
+        $submission = $this->createSubmission();
+        $style_criteria = $this->createStyleCriteria($submission->publication->id);
+        InlineComment::factory()->count($count)->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an inline comment created by PHPUnit.',
+            'created_by' => $user->id,
+            'updated_by' => $user->id,
+            'style_criteria' => [$style_criteria],
+        ]);
+
+        return $submission;
+    }
+
+    /**
+     * @param int $count
+     * @param User|null $user (optional)
+     * @return Submission
+     */
+    protected function createSubmissionWithOverallComment($count = 1, $user = null)
+    {
+        if ($user === null) {
+            $user = User::factory()->create();
+        }
+        $submission = $this->createSubmission();
+        OverallComment::factory()->count($count)->create([
+            'submission_id' => $submission->id,
+            'content' => 'This is some content for an overall comment created by PHPUnit.',
+            'created_by' => $user->id,
+            'updated_by' => $user->id,
+        ]);
+
+        return $submission;
+    }
+}

--- a/backend/tests/TestFactory.php
+++ b/backend/tests/TestFactory.php
@@ -8,9 +8,12 @@ use App\Models\OverallComment;
 use App\Models\StyleCriteria;
 use App\Models\Submission;
 use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
 
 trait TestFactory
 {
+    use WithFaker;
+
     /**
      * @param int $status (default: Submission::UNDER_REVIEW)
      * @return Submission
@@ -95,10 +98,20 @@ trait TestFactory
     {
         $submission = $this->createSubmission();
         $submission->submitters->first();
-        $submission->reviewers()->attach([User::factory()->create()->id]);
-        $submission->reviewCoordinators()->attach([User::factory()->create()->id]);
-        $submission->publication->editors()->attach([User::factory()->create()->id]);
-        $submission->publication->publicationAdmins()->attach([User::factory()->create()->id]);
+
+        $users = collect();
+        for ($i = 0; $i < 4; $i++) {
+            $users->push(
+                User::factory()->create([
+                    'username' => $this->faker->unique()->userName,
+                    'email' => $this->faker->unique()->safeEmail
+                ])
+            );
+        }
+        $submission->reviewers()->attach([$users->slice(0,1)->first()->id]);
+        $submission->reviewCoordinators()->attach([$users->slice(1,1)->first()->id]);
+        $submission->publication->editors()->attach([$users->slice(2,1)->first()->id]);
+        $submission->publication->publicationAdmins()->attach([$users->slice(3,1)->first()->id]);
         return $submission;
     }
 }

--- a/backend/tests/TestFactory.php
+++ b/backend/tests/TestFactory.php
@@ -84,4 +84,21 @@ trait TestFactory
 
         return $submission;
     }
+
+    /**
+     * Create a submission with users that have all submission-relative and publication-relative roles.
+     * Does not include Application Administrator role.
+     *
+     * @return Submission
+     */
+    protected function createSubmissionWithAllRoles(): Submission
+    {
+        $submission = $this->createSubmission();
+        $submission->submitters->first();
+        $submission->reviewers()->attach([User::factory()->create()->id]);
+        $submission->reviewCoordinators()->attach([User::factory()->create()->id]);
+        $submission->publication->editors()->attach([User::factory()->create()->id]);
+        $submission->publication->publicationAdmins()->attach([User::factory()->create()->id]);
+        return $submission;
+    }
 }

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -48,6 +48,9 @@ export const CURRENT_USER_NOTIFICATIONS = gql`
             submission {
               title
             }
+            commentor {
+              display_label
+            }
             invitee {
               display_label
             }

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1033,6 +1033,11 @@
           "short": "{data_commentor_display_label} added a new inline comment to {data_submission_title}"
         }
       },
+      "inline_comment_reply": {
+        "added": {
+          "short": "{data_commentor_display_label} replied to an inline comment for {data_submission_title}"
+        }
+      },
       "invitation": {
         "review_coordinator": {
           "accepted": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1028,6 +1028,11 @@
       "filter": "Filter"
     },
     "submission": {
+      "inline_comment": {
+        "added": {
+          "short": "{data_commentor_display_label} added a new inline comment to {data_submission_title}"
+        }
+      },
       "invitation": {
         "review_coordinator": {
           "accepted": {

--- a/client/src/i18n/en-US.json
+++ b/client/src/i18n/en-US.json
@@ -1028,6 +1028,16 @@
       "filter": "Filter"
     },
     "submission": {
+      "overall_comment": {
+        "added": {
+          "short": "{data_commentor_display_label} added a new overall comment to {data_submission_title}"
+        }
+      },
+      "overall_comment_reply": {
+        "added": {
+          "short": "{data_commentor_display_label} replied to an overall comment for {data_submission_title}"
+        }
+      },
       "inline_comment": {
         "added": {
           "short": "{data_commentor_display_label} added a new inline comment to {data_submission_title}"

--- a/client/src/mappers/notification_icons.js
+++ b/client/src/mappers/notification_icons.js
@@ -23,6 +23,9 @@ const icons = flatten({
     overall_comment: {
       added: "chat",
     },
+    overall_comment_reply: {
+      added: "chat",
+    },
     invitation: {
       review_coordinator: {
         accepted: "emoji_people",

--- a/client/src/mappers/notification_icons.js
+++ b/client/src/mappers/notification_icons.js
@@ -17,6 +17,9 @@ const icons = flatten({
     inline_comment: {
       added: "chat_bubble",
     },
+    inline_comment_reply: {
+      added: "chat_bubble",
+    },
     overall_comment: {
       added: "chat",
     },

--- a/client/src/mappers/notification_icons.js
+++ b/client/src/mappers/notification_icons.js
@@ -14,6 +14,12 @@ const icons = flatten({
     revision_requested: "undo",
     archived: "inventory_2",
     deleted: "delete",
+    inline_comment: {
+      added: "chat_bubble",
+    },
+    overall_comment: {
+      added: "chat",
+    },
     invitation: {
       review_coordinator: {
         accepted: "emoji_people",


### PR DESCRIPTION
This pull request:

* Adds notifications for the following kinds of comments
    * inline comments
        * recipients
            * submitters
            * review coordinators
    * inline comment replies
        * recipients
            * submitters
            * reviewers with an inline comment reply of the parent inline comment
            * review coordinators
    * overall comments
        * recipients
            * submitters
            * review coordinators
    * overall comment replies
        * recipients
            * submitters
            * reviewers with an overall comment reply of the parent inline comment
            * review coordinators

Closes #2072 
