### PR TITLE
ci: :package: push frontend assets bundle to ghcr as an supply chain artifact

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -109,7 +109,7 @@ runs:
               METADATA: ${{ steps.docker-bake.outputs.metadata }}
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              image=$(echo $METADATA | jq -r '.web."image.name"') \
+              echo $METADATA | jq -r '.web."image.name"'
               oras attach $image \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -93,7 +93,7 @@ runs:
           run: |
               touch metadata.json
               echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
-              image=$(cat metadata.json | jq -r '.fpm."image.name"')
+              image=$(cat metadata.json | jq -r '.web."image.name"') \
               echo IMAGE_NAME=$image >> "$GITHUB_OUTPUT"
         - name: tgz Frontend Assets
           shell: bash

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,107 +1,107 @@
 name: Build
 description: "Builds the Docker images for Pilcrow"
 inputs:
-  target:
-    description: "package to build"
-    required: false
-    default: "default"
-  token:
-    description: "GitHub token to use for authentication"
+    target:
+        description: "package to build"
+        required: false
+        default: "default"
+    token:
+        description: "GitHub token to use for authentication"
 outputs:
-  version:
-    description: "Version of the package that was built"
-    value: ${{ steps.docker-meta-fpm.outputs.version }}
-  tags:
-    description: "List of tags"
-    value: ${{ steps.docker-meta-fpm.outputs.tags}}
+    version:
+        description: "Version of the package that was built"
+        value: ${{ steps.docker-meta-fpm.outputs.version }}
+    tags:
+        description: "List of tags"
+        value: ${{ steps.docker-meta-fpm.outputs.tags}}
 runs:
-  using: "composite"
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set version strings
-      id: tagger
-      shell: bash
-      run: |
-        VERSION=$(git describe --tags)
-        VERSION_URL=https://github.com/MESH-Research/Pilcrow/commits/${GITHUB_SHA}
-        VERSION_DATE=$(git show -s --format=%cI ${GITHUB_SHA})
-        echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-        echo "VERSION_URL=${VERSION_URL}" >> "$GITHUB_ENV"
-        echo "VERSION_DATE=${VERSION_DATE}" >> "$GITHUB_ENV"
-        echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
-        sed -i "s|env('VERSION', '')|env('VERSION', '${VERSION}')|" backend/config/app.php
-        sed -i "s|env('VERSION_URL', '')|env('VERSION_URL', '${VERSION_URL}')|" backend/config/app.php
-        sed -i "s|env('VERSION_DATE', '')|env('VERSION_DATE', '${VERSION_DATE}')|" backend/config/app.php
-        sed -i "s|process.env.VERSION_DATE|'${VERSION_DATE}'|" client/src/components/AppFooter.vue
-        sed -i "s|process.env.VERSION_URL|'${VERSION_URL}'|" client/src/components/AppFooter.vue
-        sed -i "s|process.env.VERSION|'${VERSION}'|" client/src/components/AppFooter.vue
-    - uses: docker/setup-buildx-action@v3
-    - name: Docker meta (FPM)
-      id: docker-meta-fpm
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/${{ github.repository }}/${{ (inputs.target == 'default' && 'cache/') || ''}}fpm
-        tags: |
-          type=edge
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,enable=${{ inputs.target == 'default'}}
-        bake-target: fpm
-    - name: Docker meta (WEB)
-      id: docker-meta-web
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/${{ env.REPO }}/${{ (inputs.target == 'default' && 'cache/') || ''}}web
-        tags: |
-          type=edge
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,enable=${{ inputs.target == 'default'}}
-        bake-target: web
-    - uses: int128/docker-build-cache-config-action@v1
-      id: cache-web
-      with:
-        image: ghcr.io/${{ env.REPO }}/cache/web
-    - uses: int128/docker-build-cache-config-action@v1
-      id: cache-fpm
-      with:
-        image: ghcr.io/${{ env.REPO }}/cache/fpm
-    - name: Build and push
-      uses: docker/bake-action@v6.8.0
-      if: ${{ steps.docker-meta-fpm.outputs.tags != ''}}
-      env:
-        FPM_CACHE_FROM: ${{ steps.cache-fpm.outputs.cache-from }}
-        FPM_CACHE_TO: ${{ steps.cache-fpm.outputs.cache-to }}
-        WEB_CACHE_FROM: ${{ steps.cache-web.outputs.cache-from }}
-        WEB_CACHE_TO: ${{ steps.cache-web.outputs.cache-to }}
-      with:
-        source: .
-        targets: ${{ inputs.target }}
-        allow: fs.write=*
-        files: |
-          ./docker-bake.hcl
-          ${{ steps.docker-meta-fpm.outputs.bake-file }}
-          ${{ steps.docker-meta-web.outputs.bake-file }}
-    - name: tgz Frontend Assets
-      shell: bash
-      run: |
-        tar -czvf frontend-bundle.tar.gz \
-          -C /tmp/webbuild/var/www/html .
-    - name: Upload Frontend Assets
-      uses: actions/upload-artifact@v4
-      with:
-        name: frontend-bundle
-        path: /tmp/webbuild/var/www/html/
-    - name: Publish Frontend Bundle
-      uses: oras-project/setup-oras@v1
-    - shell: bash
-      run: |
-        echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-        oras attach ghcr.io/${{ github.repository_owner }}/pilcrow/web:${{ steps.docker-meta-web.outputs.version }} \
-          --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
-          frontend-bundle.tar.gz
+    using: "composite"
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+              fetch-depth: 0
+        - name: Set version strings
+          id: tagger
+          shell: bash
+          run: |
+              VERSION=$(git describe --tags)
+              VERSION_URL=https://github.com/MESH-Research/Pilcrow/commits/${GITHUB_SHA}
+              VERSION_DATE=$(git show -s --format=%cI ${GITHUB_SHA})
+              echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+              echo "VERSION_URL=${VERSION_URL}" >> "$GITHUB_ENV"
+              echo "VERSION_DATE=${VERSION_DATE}" >> "$GITHUB_ENV"
+              echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+              sed -i "s|env('VERSION', '')|env('VERSION', '${VERSION}')|" backend/config/app.php
+              sed -i "s|env('VERSION_URL', '')|env('VERSION_URL', '${VERSION_URL}')|" backend/config/app.php
+              sed -i "s|env('VERSION_DATE', '')|env('VERSION_DATE', '${VERSION_DATE}')|" backend/config/app.php
+              sed -i "s|process.env.VERSION_DATE|'${VERSION_DATE}'|" client/src/components/AppFooter.vue
+              sed -i "s|process.env.VERSION_URL|'${VERSION_URL}'|" client/src/components/AppFooter.vue
+              sed -i "s|process.env.VERSION|'${VERSION}'|" client/src/components/AppFooter.vue
+        - uses: docker/setup-buildx-action@v3
+        - name: Docker meta (FPM)
+          id: docker-meta-fpm
+          uses: docker/metadata-action@v5
+          with:
+              images: |
+                  ghcr.io/${{ github.repository }}/${{ (inputs.target == 'default' && 'cache/') || ''}}fpm
+              tags: |
+                  type=edge
+                  type=semver,pattern={{version}}
+                  type=semver,pattern={{major}}.{{minor}}
+                  type=sha,enable=${{ inputs.target == 'default'}}
+              bake-target: fpm
+        - name: Docker meta (WEB)
+          id: docker-meta-web
+          uses: docker/metadata-action@v5
+          with:
+              images: |
+                  ghcr.io/${{ env.REPO }}/${{ (inputs.target == 'default' && 'cache/') || ''}}web
+              tags: |
+                  type=edge
+                  type=semver,pattern={{version}}
+                  type=semver,pattern={{major}}.{{minor}}
+                  type=sha,enable=${{ inputs.target == 'default'}}
+              bake-target: web
+        - uses: int128/docker-build-cache-config-action@v1
+          id: cache-web
+          with:
+              image: ghcr.io/${{ env.REPO }}/cache/web
+        - uses: int128/docker-build-cache-config-action@v1
+          id: cache-fpm
+          with:
+              image: ghcr.io/${{ env.REPO }}/cache/fpm
+        - name: Build and push
+          uses: docker/bake-action@v6.8.0
+          if: ${{ steps.docker-meta-fpm.outputs.tags != ''}}
+          env:
+              FPM_CACHE_FROM: ${{ steps.cache-fpm.outputs.cache-from }}
+              FPM_CACHE_TO: ${{ steps.cache-fpm.outputs.cache-to }}
+              WEB_CACHE_FROM: ${{ steps.cache-web.outputs.cache-from }}
+              WEB_CACHE_TO: ${{ steps.cache-web.outputs.cache-to }}
+          with:
+              source: .
+              targets: ${{ inputs.target }}
+              allow: fs.write=*
+              files: |
+                  ./docker-bake.hcl
+                  ${{ steps.docker-meta-fpm.outputs.bake-file }}
+                  ${{ steps.docker-meta-web.outputs.bake-file }}
+        - name: tgz Frontend Assets
+          shell: bash
+          run: |
+              tar -czvf frontend-bundle.tar.gz \
+                -C /tmp/webbuild/var/www/html .
+        - name: Upload Frontend Assets
+          uses: actions/upload-artifact@v4
+          with:
+              name: frontend-bundle
+              path: /tmp/webbuild/var/www/html/
+        - name: Publish Frontend Bundle
+          uses: oras-project/setup-oras@v1
+        - shell: bash
+          run: |
+              echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
+              oras attach ghcr.io/${{ github.repository_owner }}/pilcrow%2fweb:${{ steps.docker-meta-web.outputs.version }} \
+                --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
+                frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -92,8 +92,10 @@ runs:
         - name: tgz Frontend Assets
           shell: bash
           run: |
-              tar -czf frontend-bundle.tar.gz \
+              echo "::group::Compress frontend assets""
+              tar -czvf frontend-bundle.tar.gz \
                 -C /tmp/webbuild/var/www/html .
+              echo "::endgroup::"
         - name: Upload Frontend Assets
           uses: actions/upload-artifact@v4
           with:
@@ -108,6 +110,6 @@ runs:
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
               image=$(echo $METADATA | jq -r '.web."image.name"') \
-              oras attach "$image" \
+              oras attach $image \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -106,10 +106,8 @@ runs:
               OWNER: ${{ github.repository_owner }}
               METADATA: ${{ steps.docker-bake.outputs.metadata }}
           run: |
-              touch metadata.json
-              echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
-              image=$(echo $METADATA | jq -r '.web."image.name"') \
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              oras attach "https://$image" \
+              image=$(echo $METADATA | jq -r '.web."image.name"') \
+              oras attach "$image" \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -100,8 +100,10 @@ runs:
         - name: Publish Frontend Bundle
           uses: oras-project/setup-oras@v1
         - shell: bash
+          env:
+              OWNER: ${{ github.repository_owner }}
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              oras attach ghcr.io/${{ github.repository_owner }}/pilcrow%2fweb:${{ steps.docker-meta-web.outputs.version }} \
+              oras attach ghcr.io/${OWNER,,}/pilcrow%2fweb:${{ steps.docker-meta-web.outputs.version }} \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,84 +1,107 @@
 name: Build
+description: "Builds the Docker images for Pilcrow"
 inputs:
-    target:
-        description: "package to build"
-        required: false
-        default: "default"
+  target:
+    description: "package to build"
+    required: false
+    default: "default"
+  token:
+    description: "GitHub token to use for authentication"
 outputs:
-    version:
-        description: "Version of the package that was built"
-        value: ${{ steps.docker-meta-fpm.outputs.version }}
-    tags:
-        description: "List of tags"
-        value: ${{ steps.docker-meta-fpm.outputs.tags}}
+  version:
+    description: "Version of the package that was built"
+    value: ${{ steps.docker-meta-fpm.outputs.version }}
+  tags:
+    description: "List of tags"
+    value: ${{ steps.docker-meta-fpm.outputs.tags}}
 runs:
-    using: "composite"
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
-        - name: Set version strings
-          id: tagger
-          shell: bash
-          run: |
-              VERSION=$(git describe --tags)
-              VERSION_URL=https://github.com/MESH-Research/Pilcrow/commits/${GITHUB_SHA}
-              VERSION_DATE=$(git show -s --format=%cI ${GITHUB_SHA})
-              echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-              echo "VERSION_URL=${VERSION_URL}" >> "$GITHUB_ENV"
-              echo "VERSION_DATE=${VERSION_DATE}" >> "$GITHUB_ENV"
-              echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
-              sed -i "s|env('VERSION', '')|env('VERSION', '${VERSION}')|" backend/config/app.php
-              sed -i "s|env('VERSION_URL', '')|env('VERSION_URL', '${VERSION_URL}')|" backend/config/app.php
-              sed -i "s|env('VERSION_DATE', '')|env('VERSION_DATE', '${VERSION_DATE}')|" backend/config/app.php
-              sed -i "s|process.env.VERSION_DATE|'${VERSION_DATE}'|" client/src/components/AppFooter.vue
-              sed -i "s|process.env.VERSION_URL|'${VERSION_URL}'|" client/src/components/AppFooter.vue
-              sed -i "s|process.env.VERSION|'${VERSION}'|" client/src/components/AppFooter.vue
-        - uses: docker/setup-buildx-action@v3
-        - name: Docker meta (FPM)
-          id: docker-meta-fpm
-          uses: docker/metadata-action@v5
-          with:
-            images: |
-              ghcr.io/${{ github.repository }}/${{ (inputs.target == 'default' && 'cache/') || ''}}fpm
-            tags: |
-              type=edge
-              type=semver,pattern={{version}}
-              type=semver,pattern={{major}}.{{minor}}
-              type=sha,enable=${{ inputs.target == 'default'}}
-            bake-target: fpm
-        - name: Docker meta (WEB)
-          id: docker-meta-web
-          uses: docker/metadata-action@v5
-          with:
-            images: |
-              ghcr.io/${{ env.REPO }}/${{ (inputs.target == 'default' && 'cache/') || ''}}web
-            tags: |
-              type=edge
-              type=semver,pattern={{version}}
-              type=semver,pattern={{major}}.{{minor}}
-              type=sha,enable=${{ inputs.target == 'default'}}
-            bake-target: web
-        - uses: int128/docker-build-cache-config-action@v1
-          id: cache-web
-          with:
-            image: ghcr.io/${{ env.REPO }}/cache/web
-        - uses: int128/docker-build-cache-config-action@v1
-          id: cache-fpm
-          with:
-            image: ghcr.io/${{ env.REPO }}/cache/fpm
-        - name: Build and push
-          uses: docker/bake-action@v4
-          if: ${{ steps.docker-meta-fpm.outputs.tags != ''}}
-          env:
-            FPM_CACHE_FROM: ${{ steps.cache-fpm.outputs.cache-from }}
-            FPM_CACHE_TO: ${{ steps.cache-fpm.outputs.cache-to }}
-            WEB_CACHE_FROM: ${{ steps.cache-web.outputs.cache-from }}
-            WEB_CACHE_TO: ${{ steps.cache-web.outputs.cache-to }}
-          with:
-            targets: ${{ inputs.target }}
-            files: |
-              ./docker-bake.hcl
-              ${{ steps.docker-meta-fpm.outputs.bake-file }}
-              ${{ steps.docker-meta-web.outputs.bake-file }}
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set version strings
+      id: tagger
+      shell: bash
+      run: |
+        VERSION=$(git describe --tags)
+        VERSION_URL=https://github.com/MESH-Research/Pilcrow/commits/${GITHUB_SHA}
+        VERSION_DATE=$(git show -s --format=%cI ${GITHUB_SHA})
+        echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+        echo "VERSION_URL=${VERSION_URL}" >> "$GITHUB_ENV"
+        echo "VERSION_DATE=${VERSION_DATE}" >> "$GITHUB_ENV"
+        echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+        sed -i "s|env('VERSION', '')|env('VERSION', '${VERSION}')|" backend/config/app.php
+        sed -i "s|env('VERSION_URL', '')|env('VERSION_URL', '${VERSION_URL}')|" backend/config/app.php
+        sed -i "s|env('VERSION_DATE', '')|env('VERSION_DATE', '${VERSION_DATE}')|" backend/config/app.php
+        sed -i "s|process.env.VERSION_DATE|'${VERSION_DATE}'|" client/src/components/AppFooter.vue
+        sed -i "s|process.env.VERSION_URL|'${VERSION_URL}'|" client/src/components/AppFooter.vue
+        sed -i "s|process.env.VERSION|'${VERSION}'|" client/src/components/AppFooter.vue
+    - uses: docker/setup-buildx-action@v3
+    - name: Docker meta (FPM)
+      id: docker-meta-fpm
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/${{ github.repository }}/${{ (inputs.target == 'default' && 'cache/') || ''}}fpm
+        tags: |
+          type=edge
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,enable=${{ inputs.target == 'default'}}
+        bake-target: fpm
+    - name: Docker meta (WEB)
+      id: docker-meta-web
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/${{ env.REPO }}/${{ (inputs.target == 'default' && 'cache/') || ''}}web
+        tags: |
+          type=edge
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,enable=${{ inputs.target == 'default'}}
+        bake-target: web
+    - uses: int128/docker-build-cache-config-action@v1
+      id: cache-web
+      with:
+        image: ghcr.io/${{ env.REPO }}/cache/web
+    - uses: int128/docker-build-cache-config-action@v1
+      id: cache-fpm
+      with:
+        image: ghcr.io/${{ env.REPO }}/cache/fpm
+    - name: Build and push
+      uses: docker/bake-action@v6.8.0
+      if: ${{ steps.docker-meta-fpm.outputs.tags != ''}}
+      env:
+        FPM_CACHE_FROM: ${{ steps.cache-fpm.outputs.cache-from }}
+        FPM_CACHE_TO: ${{ steps.cache-fpm.outputs.cache-to }}
+        WEB_CACHE_FROM: ${{ steps.cache-web.outputs.cache-from }}
+        WEB_CACHE_TO: ${{ steps.cache-web.outputs.cache-to }}
+      with:
+        source: .
+        targets: ${{ inputs.target }}
+        allow: fs.write=*
+        files: |
+          ./docker-bake.hcl
+          ${{ steps.docker-meta-fpm.outputs.bake-file }}
+          ${{ steps.docker-meta-web.outputs.bake-file }}
+    - name: tgz Frontend Assets
+      shell: bash
+      run: |
+        tar -czvf frontend-bundle.tar.gz \
+          -C /tmp/webbuild/var/www/html .
+    - name: Upload Frontend Assets
+      uses: actions/upload-artifact@v4
+      with:
+        name: frontend-bundle
+        path: /tmp/webbuild/var/www/html/
+    - name: Publish Frontend Bundle
+      uses: oras-project/setup-oras@v1
+    - shell: bash
+      run: |
+        echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
+        oras attach ghcr.io/${{ github.repository_owner }}/pilcrow/web:${{ steps.docker-meta-web.outputs.version }} \
+          --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
+          frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -88,13 +88,7 @@ runs:
                   ./docker-bake.hcl
                   ${{ steps.docker-meta-fpm.outputs.bake-file }}
                   ${{ steps.docker-meta-web.outputs.bake-file }}
-        - name: Get image from metadata
-          shell: bash
-          run: |
-              touch metadata.json
-              echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
-              image=$(cat metadata.json | jq -r '.web."image.name"') \
-              echo IMAGE_NAME=$image >> "$GITHUB_OUTPUT"
+
         - name: tgz Frontend Assets
           shell: bash
           run: |
@@ -111,6 +105,10 @@ runs:
           env:
               OWNER: ${{ github.repository_owner }}
           run: |
+              touch metadata.json
+              echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
+              image=$(cat metadata.json | jq -r '.web."image.name"') \
+              echo "IMAGE_NAME=${image}" >> "$GITHUB_ENV"
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
               oras attach ${{ env.IMAGE_NAME }} \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -93,11 +93,12 @@ runs:
           run: |
               touch metadata.json
               echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
-              echo IMAGE_NAME=$(cat metadata.json | jq '.web."image.name"') >> "$GITHUB_OUTPUT"
+              image=$(cat metadata.json | jq -r '.fpm."image.name"')
+              echo IMAGE_NAME=$image >> "$GITHUB_OUTPUT"
         - name: tgz Frontend Assets
           shell: bash
           run: |
-              tar -czvf frontend-bundle.tar.gz \
+              tar -czf frontend-bundle.tar.gz \
                 -C /tmp/webbuild/var/www/html .
         - name: Upload Frontend Assets
           uses: actions/upload-artifact@v4

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -89,7 +89,6 @@ runs:
                   ${{ steps.docker-meta-fpm.outputs.bake-file }}
                   ${{ steps.docker-meta-web.outputs.bake-file }}
         - name: Get image from metadata
-          id: docker-meta-web
           shell: bash
           run: |
               touch metadata.json

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -104,12 +104,12 @@ runs:
         - shell: bash
           env:
               OWNER: ${{ github.repository_owner }}
+              METADATA: ${{ steps.docker-bake.outputs.metadata }}
           run: |
               touch metadata.json
               echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
-              image=$(cat metadata.json | jq -r '.web."image.name"') \
-              echo "IMAGE_NAME=${image}" >> "$GITHUB_ENV"
+              image=$(echo $METADATA | jq -r '.web."image.name"') \
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              oras attach ${{ env.IMAGE_NAME }} \
+              oras attach "https://$image" \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -72,6 +72,7 @@ runs:
           with:
               image: ghcr.io/${{ env.REPO }}/cache/fpm
         - name: Build and push
+          id: docker-bake
           uses: docker/bake-action@v6.8.0
           if: ${{ steps.docker-meta-fpm.outputs.tags != ''}}
           env:
@@ -87,6 +88,13 @@ runs:
                   ./docker-bake.hcl
                   ${{ steps.docker-meta-fpm.outputs.bake-file }}
                   ${{ steps.docker-meta-web.outputs.bake-file }}
+        - name: Get image from metadata
+          id: docker-meta-web
+          shell: bash
+          run: |
+              touch metadata.json
+              echo '${{ steps.docker-bake.outputs.metadata }}' > metadata.json
+              echo IMAGE_NAME=$(cat metadata.json | jq '.web."image.name"') >> "$GITHUB_OUTPUT"
         - name: tgz Frontend Assets
           shell: bash
           run: |
@@ -104,6 +112,6 @@ runs:
               OWNER: ${{ github.repository_owner }}
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              oras attach ghcr.io/${OWNER,,}/pilcrow%2fweb:${{ steps.docker-meta-web.outputs.version }} \
+              oras attach $IMAGE_NAME \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -109,7 +109,7 @@ runs:
               METADATA: ${{ steps.docker-bake.outputs.metadata }}
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              echo $METADATA | jq -r '.web."image.name"'
+              image="$(echo $METADATA | jq -r '.web."image.name"')"
               oras attach $image \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -111,6 +111,6 @@ runs:
               OWNER: ${{ github.repository_owner }}
           run: |
               echo ${{ inputs.token }} | oras login --username wreality --password-stdin ghcr.io
-              oras attach $IMAGE_NAME \
+              oras attach ${{ env.IMAGE_NAME }} \
                 --artifact-type application/vnd.mesh.frontend-bundle.v1+tar \
                 frontend-bundle.tar.gz

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -92,7 +92,7 @@ runs:
         - name: tgz Frontend Assets
           shell: bash
           run: |
-              echo "::group::Compress frontend assets""
+              echo "::group::Compress frontend assets"
               tar -czvf frontend-bundle.tar.gz \
                 -C /tmp/webbuild/var/www/html .
               echo "::endgroup::"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,8 @@ jobs:
       - uses: ./.github/actions/build-image
         id: build-image
         name: Build Image
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
   backend-unit-test:
     name: Backend / Unit Test
     needs: [build-images]
@@ -146,6 +148,8 @@ jobs:
         id: build-image
         with:
           target: release
+          token: ${{ secrets.REPO_TOKEN }}
+
   deployments:
     runs-on: ubuntu-24.04
     needs:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -48,7 +48,7 @@ target "web" {
     labels = {
         "org.opencontainers.image.description" = "Pilcrow WEB Container Image version: ${ VERSION }@${VERSION_DATE } (${ VERSION_URL })"
     }
-    output = ["type=image,push=true,annotation-index.org.opencontainers.image.description=Pilcrow WEB Container Image version: ${ VERSION }@${VERSION_DATE } (${ VERSION_URL })"]
+    output = ["type=image,push=true,annotation-index.org.opencontainers.image.description=Pilcrow WEB Container Image version: ${ VERSION }@${VERSION_DATE } (${ VERSION_URL })", "type=local,dest=/tmp/webbuild"]
     cache-from = ["${WEB_CACHE_FROM}", "type=registry,ref=ghcr.io/mesh-research/pilcrow/web:edge"]
     cache-to = ["${WEB_CACHE_TO}"]
 }


### PR DESCRIPTION
To make it slightly easier to get the frontend bundle when priming a CDN, we zip up the bundle from the build process and attach to the web container image as a related artifact.

This pull request introduces updates to the Docker image build process and CI workflow for Pilcrow. Key changes include enhancements to the `.github/actions/build-image` action, modifications to the CI workflow to support token usage, and updates to the `docker-bake.hcl` file to enable local output for web builds.

### Enhancements to Docker image build process:
* [`.github/actions/build-image/action.yaml`](diffhunk://#diff-7360bea25001af0257834160753c7ae85cf9677376c4f19212a700635021fe90R2-R9): Added a description for the action and introduced a new `token` input for GitHub authentication. Updated the `docker/bake-action` version to `v6.8.0`, added support for `fs.write` permissions, and included steps to bundle and upload frontend assets. A new step was added to publish the frontend bundle using `oras-project`. [[1]](diffhunk://#diff-7360bea25001af0257834160753c7ae85cf9677376c4f19212a700635021fe90R2-R9) [[2]](diffhunk://#diff-7360bea25001af0257834160753c7ae85cf9677376c4f19212a700635021fe90L72-R107)

### Updates to CI workflow:
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R59-R60): Added `token` input to the `build-image` job, referencing `secrets.GITHUB_TOKEN` and `secrets.REPO_TOKEN` for authentication. This ensures secure access during the build process. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R59-R60) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R151-R152)

### Modifications to Docker build configuration:
* [`docker-bake.hcl`](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L51-R51): Updated the `web` target to include a new local output destination (`/tmp/webbuild`) for web builds, facilitating the creation of frontend asset bundles.