### PR TITLE
fix(client): replace vite-plugin-checker eslint with vite-plugin-eslint2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -83,6 +83,7 @@
     "typescript": "~5.7.0",
     "typescript-eslint": "^8.54.0",
     "vite-plugin-checker": "^0.12.0",
+    "vite-plugin-eslint2": "^5.1.0",
     "vite-plugin-graphql-codegen": "^3.8.0",
     "vitest": "^1.0.0",
     "vue-composable-tester": "^0.1.3",

--- a/client/quasar.config.ts
+++ b/client/quasar.config.ts
@@ -130,12 +130,15 @@ export default defineConfig(function (/* ctx */) {
           "vite-plugin-checker",
           {
             vueTsc: true,
-            eslint: {
-              lintCommand:
-                'eslint -c ./eslint.config.js "./src*/**/*.{js,mjs,cjs,ts,mts,vue}"'
-            }
           },
           { server: false }
+        ],
+        [
+          "vite-plugin-eslint2",
+          {
+            lintOnStart: true,
+            fix: false,
+          }
         ],
         [
           "vite-plugin-graphql-codegen",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1474,6 +1474,15 @@
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz#be23df0143ceec3c69f8b6c2517971a5578fdaa2"
   integrity sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==
 
+"@rollup/pluginutils@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
+  integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
 "@rollup/rollup-android-arm-eabi@4.59.0":
   version "4.59.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz#a6742c74c7d9d6d604ef8a48f99326b4ecda3d82"
@@ -7365,6 +7374,14 @@ vite-plugin-checker@^0.12.0:
     tiny-invariant "^1.3.3"
     tinyglobby "^0.2.15"
     vscode-uri "^3.1.0"
+
+vite-plugin-eslint2@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-eslint2/-/vite-plugin-eslint2-5.1.0.tgz#c796d4dc852b35f91db508946a4833589adea319"
+  integrity sha512-fNuO/D7b+EZ5ejhuBA80tiaxWztZWDHc+lCZaXMOHgYfqFXq8WKmGwrudS+/jscp0UNAKGB71du+xoP8azSXiw==
+  dependencies:
+    "@rollup/pluginutils" "^5.3.0"
+    debug "^4.4.3"
 
 vite-plugin-graphql-codegen@^3.8.0:
   version "3.8.0"


### PR DESCRIPTION
## Summary
- **vite-plugin-checker v0.12.0 does not support ESLint v10** ([fi3ework/vite-plugin-checker#647](https://github.com/fi3ework/vite-plugin-checker/issues/647)). Neither code path works: the legacy path passes removed v8 options, and the `useFlatConfig` path tries to import `FlatESLint` which was removed in v10.
- Replaced the eslint checker in vite-plugin-checker with [vite-plugin-eslint2](https://github.com/ModyQyW/vite-plugin-eslint2), which supports ESLint v7–v10.
- Kept vite-plugin-checker for `vueTsc` type checking only.

## Test plan
- [x] Verified client container starts without ESLint errors
- [x] Verified lint errors are detected by introducing an unused variable