### PR TITLE
chore: disable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,19 +32,6 @@
             "matchFileNames": ["client/**"]
         },
         /**
-         * AUTOMATED MERGING:
-         * Backend and client are well covered in automated testing, so we'll
-         * attempt to automerge patch updates.
-         **/
-        {
-            "matchUpdateTypes": ["patch"],
-            "matchCurrentVersion": "!/^0/",
-            "matchFileNames": ["backend/**", "client/**"],
-            "matchManagers": ["npm","composer"],
-            "automerge": true,
-            "automergeType": "branch"
-        },
-        /**
          * Group client npm updates
          **/
         {


### PR DESCRIPTION
## Summary
- Removes the automerge rule from `renovate.json` that was automatically merging patch-level dependency updates for npm and composer packages
- All dependency updates now require manual review and merge via PR

## Motivation
Recent npm package vulnerabilities make it prudent to review all dependency updates before merging, rather than allowing Renovate to automerge patches.

## Test plan
- [x] Verify Renovate no longer automerges patch updates and instead opens PRs for review