### PR TITLE
fix: render SPA index for password reset route

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -19,9 +19,9 @@ Route::get('/', function () {
 });
 // This route is unreachable in the deployed application (the front hands off the request to GraphQL).
 // This route is added to provide the the reverse routing to generate the URL in password reset emails.
-Route::get('/reset-password/{token}', function (string $token) {
-    return view('auth.reset-password', ['token' => $token]);
-})->middleware('guest')->name('password.reset');
+Route::get('/reset-password/{token}', function () {
+    return view('index');
+})->name('password.reset');
 
 // Catch-all route for SPA deep linking. All unmatched routes serve the index
 // view so that Vue Router can handle client-side routing. This must remain the


### PR DESCRIPTION
## Summary
- `/reset-password/{token}` was rendering a non-existent `auth.reset-password` view, breaking links from password reset emails
- Render the SPA `index` view instead so Vue Router handles the token client-side
- Drop the `guest` middleware to match the catch-all SPA route (auth handled client-side)

## Test plan
- [x] Trigger password reset email locally; click link and confirm the SPA loads with the reset form
- [x] Confirm `route('password.reset', ...)` reverse routing still produces the expected URL in the email