### PR TITLE
fix: add correct check for dev banner to appear

### DIFF
--- a/client/src/components/LocalDevBanner.vue
+++ b/client/src/components/LocalDevBanner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="dirName != 'pilcrow'" class="local-dev-banner">
+  <div v-if="showBanner"  class="local-dev-banner">
     <span>📂 {{ dirName }}</span>
     <a
       href="/graphiql"
@@ -43,6 +43,7 @@
 <script setup lang="ts">
 const appRoot = process.env.LANDO_APP_ROOT as string | undefined
 const dirName = appRoot?.split("/").pop() ?? null
+const showBanner = appRoot !== undefined && dirName !== 'pilcrow'
 </script>
 
 <style scoped lang="sass">


### PR DESCRIPTION
This pull request updates the logic for displaying the local development banner in the `LocalDevBanner.vue` component. The banner will now only be shown if the `LANDO_APP_ROOT` environment variable is defined and its directory name is not `'pilcrow'`.

**Logic update for banner display:**

* Changed the conditional rendering to use a new `showBanner` variable, which checks both that `appRoot` is defined and `dirName` is not `'pilcrow'` (`LocalDevBanner.vue`). [[1]](diffhunk://#diff-c108bb4b7a49221167e8fa8dfbb21d9ae032b2d848a97c76f97b203c8e20818fL2-R2) [[2]](diffhunk://#diff-c108bb4b7a49221167e8fa8dfbb21d9ae032b2d848a97c76f97b203c8e20818fR46)