### PR TITLE
fix: serve app banner config from Laravel runtime not build env

### DIFF
--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -17,7 +17,7 @@ return [
 
     'name' => env('APP_NAME', 'Pilcrow'),
 
-    'banner' => env('APP_BANNER'),
+    'banner_text' => env('APP_BANNER_TEXT'),
     'banner_class' => env('APP_BANNER_CLASS'),
     'banner_link' => env('APP_BANNER_LINK'),
 

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -17,6 +17,10 @@ return [
 
     'name' => env('APP_NAME', 'Pilcrow'),
 
+    'banner' => env('APP_BANNER'),
+    'banner_class' => env('APP_BANNER_CLASS'),
+    'banner_link' => env('APP_BANNER_LINK'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/backend/resources/views/index.blade.php
+++ b/backend/resources/views/index.blade.php
@@ -24,6 +24,8 @@
         return '/' + filename;
       }
     @endif
+    @php($appBanner = ['text' => config('app.banner'), 'class' => config('app.banner_class'), 'link' => config('app.banner_link')])
+    window.__APP_BANNER = @json($appBanner);
   </script>
   @env('local', 'development', 'dev')
     @vite_dev_scripts

--- a/backend/resources/views/index.blade.php
+++ b/backend/resources/views/index.blade.php
@@ -24,7 +24,7 @@
         return '/' + filename;
       }
     @endif
-    @php($appBanner = ['text' => config('app.banner'), 'class' => config('app.banner_class'), 'link' => config('app.banner_link')])
+    @php($appBanner = ['text' => config('app.banner_text'), 'class' => config('app.banner_class'), 'link' => config('app.banner_link')])
     window.__APP_BANNER = @json($appBanner);
   </script>
   @env('local', 'development', 'dev')

--- a/backend/tests/Feature/AppBannerInjectionTest.php
+++ b/backend/tests/Feature/AppBannerInjectionTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class AppBannerInjectionTest extends TestCase
+{
+    public function testBannerInjectedWhenConfigSet(): void
+    {
+        config([
+            'app.banner' => 'Heads up',
+            'app.banner_class' => 'bg-red-2 text-black',
+            'app.banner_link' => 'https://example.com/notice',
+        ]);
+
+        $expected = 'window.__APP_BANNER = ' . json_encode([
+            'text' => 'Heads up',
+            'class' => 'bg-red-2 text-black',
+            'link' => 'https://example.com/notice',
+        ]);
+
+        $this->get('/')
+            ->assertStatus(200)
+            ->assertSee($expected, false);
+    }
+
+    public function testBannerNullWhenConfigUnset(): void
+    {
+        config([
+            'app.banner' => null,
+            'app.banner_class' => null,
+            'app.banner_link' => null,
+        ]);
+
+        $expected = 'window.__APP_BANNER = ' . json_encode([
+            'text' => null,
+            'class' => null,
+            'link' => null,
+        ]);
+
+        $this->get('/')
+            ->assertStatus(200)
+            ->assertSee($expected, false);
+    }
+}

--- a/backend/tests/Feature/AppBannerInjectionTest.php
+++ b/backend/tests/Feature/AppBannerInjectionTest.php
@@ -10,7 +10,7 @@ class AppBannerInjectionTest extends TestCase
     public function testBannerInjectedWhenConfigSet(): void
     {
         config([
-            'app.banner' => 'Heads up',
+            'app.banner_text' => 'Heads up',
             'app.banner_class' => 'bg-red-2 text-black',
             'app.banner_link' => 'https://example.com/notice',
         ]);
@@ -29,7 +29,7 @@ class AppBannerInjectionTest extends TestCase
     public function testBannerNullWhenConfigUnset(): void
     {
         config([
-            'app.banner' => null,
+            'app.banner_text' => null,
             'app.banner_class' => null,
             'app.banner_link' => null,
         ]);

--- a/client/quasar.config.ts
+++ b/client/quasar.config.ts
@@ -100,11 +100,8 @@ export default defineConfig(function (/* ctx */) {
         VERSION: process.env.VERSION ?? undefined,
         VERSION_URL: process.env.VERSION_URL ?? undefined,
         VERSION_DATE: process.env.VERSION_DATE ?? undefined,
-        APP_BANNER: process.env.APP_BANNER ?? undefined,
         LANDO_APP_ROOT: process.env.LANDO_APP_ROOT_BIND ?? undefined,
-        LANDO_DEV: !!process.env.LANDO_APP_ROOT_BIND,
-        APP_BANNER_CLASS: process.env.APP_BANNER_CLASS ?? undefined,
-        APP_BANNER_LINK: process.env.APP_BANNER_LINK ?? undefined
+        LANDO_DEV: !!process.env.LANDO_APP_ROOT_BIND
       },
       // vueRouterBase,
       // vueDevtools,

--- a/client/src/components/AppBanner.vue
+++ b/client/src/components/AppBanner.vue
@@ -33,9 +33,16 @@ const { localStorage } = useQuasar()
 const sKey = "hideBannerUntil"
 const hideBanner = ref(false)
 
-const banner = process.env.APP_BANNER ?? null
-const banner_class = process.env.APP_BANNER_CLASS ?? "bg-yellow-2 text-black"
-const banner_link = process.env.APP_BANNER_LINK ?? null
+interface AppBannerConfig {
+  text?: string | null
+  class?: string | null
+  link?: string | null
+}
+const cfg: AppBannerConfig =
+  (window as unknown as { __APP_BANNER?: AppBannerConfig }).__APP_BANNER ?? {}
+const banner = cfg.text || null
+const banner_class = cfg.class || "bg-yellow-2 text-black"
+const banner_link = cfg.link || null
 
 if (localStorage.has(sKey)) {
   const until = localStorage.getItem(sKey) as number

--- a/client/src/components/AppBanner.vue
+++ b/client/src/components/AppBanner.vue
@@ -38,8 +38,12 @@ interface AppBannerConfig {
   class?: string | null
   link?: string | null
 }
-const cfg: AppBannerConfig =
-  (window as unknown as { __APP_BANNER?: AppBannerConfig }).__APP_BANNER ?? {}
+declare global {
+  interface Window {
+    __APP_BANNER?: AppBannerConfig
+  }
+}
+const cfg: AppBannerConfig = window.__APP_BANNER ?? {}
 const banner = cfg.text || null
 const banner_class = cfg.class || "bg-yellow-2 text-black"
 const banner_link = cfg.link || null

--- a/client/src/components/AppBanner.vue
+++ b/client/src/components/AppBanner.vue
@@ -8,7 +8,7 @@
   >
     <div>
       {{ banner }}
-      <a v-if="banner_link" :href="banner_link">{{
+      <a v-if="banner_link" :href="banner_link" class="text-primary">{{
         $t("generic.more_info")
       }}</a>
     </div>


### PR DESCRIPTION
## Summary
- `APP_BANNER`, `APP_BANNER_CLASS`, `APP_BANNER_LINK` were declared in `quasar.config.ts` `build.env` but never propagated through `docker-bake.hcl` or the `mesh-research/github-actions/build-image` action, so the feature was inert at every deploy
- Move banner config to Laravel (`backend/config/app.php`), serve it to the SPA via `window.__APP_BANNER` from the existing `index.blade.php` injection block (same pattern as `window.__toCdnUrl`)
- Banner is now toggled via FPM container env (Helm values → ConfigMap → env) without rebuilding the client image

## Test plan
- [x] Set `APP_BANNER=Test message` (and optionally `APP_BANNER_CLASS`, `APP_BANNER_LINK`) on the FPM container, reload the SPA, confirm banner renders
- [x] Unset `APP_BANNER`, reload, confirm banner does not render and there are no console errors
- [x] Confirm \`window.__APP_BANNER\` is present in the served HTML when the SPA index is rendered by Laravel
- [x] Verify dismiss-for-a-week behavior still works (no regression in `LocalStorage` flow)

## Local dev note
To test the banner locally, set `APP_BANNER` (and optionally `APP_BANNER_CLASS`, `APP_BANNER_LINK`) in your `.env`. Whenever you change those values, you must:
1. `lando rebuild -s appserver` (or `lando restart`) to refresh the appserver env
2. Hard reload in the browser to refetch the index from Laravel — banner config is injected server-side into `index.blade.php`, so a soft reload of the SPA will not pick up new values