### PR TITLE
fix: serve stable avatar color from backend

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -334,4 +334,39 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->attributes['name'] ?: $this->attributes['username'];
     }
+
+    /**
+     * Deterministic avatar color name derived from the user's email (or id
+     * when no email is set). Mirrors the legacy client-side hash so existing
+     * avatars remain stable while emails are no longer exposed publicly.
+     *
+     * @return string
+     */
+    public function getAvatarColorAttribute(): string
+    {
+        $colors = [
+            'blue',
+            'cyan',
+            'green',
+            'magenta',
+            'orange',
+            'pine',
+            'purple',
+            'red',
+            'yellow',
+        ];
+
+        $seed = $this->attributes['email'] ?? (string)$this->attributes['id'];
+
+        $hash = 0;
+        $len = strlen($seed);
+        for ($i = 0; $i < $len; $i++) {
+            $hash = (($hash << 5) - $hash + ord($seed[$i])) & 0xFFFFFFFF;
+            if ($hash & 0x80000000) {
+                $hash -= 0x100000000;
+            }
+        }
+
+        return $colors[abs($hash) % count($colors)];
+    }
 }

--- a/backend/graphql/user.graphql
+++ b/backend/graphql/user.graphql
@@ -6,6 +6,7 @@ type User {
     display_label: String
     name: String
     email: String!
+    avatar_color: String! @deprecated(reason: "Temporary placeholder for stable avatar colors; will be removed when user-uploaded avatars are introduced.")
     username: String!
     created_at: DateTime!
     updated_at: DateTime

--- a/backend/tests/Feature/UserTest.php
+++ b/backend/tests/Feature/UserTest.php
@@ -155,4 +155,28 @@ class UserTest extends TestCase
         $this->assertNotEmpty($username2);
         $this->assertNotEquals($username1, $username2);
     }
+
+    /**
+     * @return void
+     */
+    public function testAvatarColorMatchesLegacyClientHash(): void
+    {
+        // Legacy client-side hash of "test@meshresearch.net" yields index 6
+        // (purple) within the colors list. Backend must produce the same value
+        // so existing avatars stay stable now that emails are not exposed.
+        $user = User::factory()->create(['email' => 'test@meshresearch.net']);
+        $this->assertSame('purple', $user->avatar_color);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAvatarColorIsOneOfKnownColors(): void
+    {
+        $user = User::factory()->create(['email' => 'colors@example.test']);
+        $this->assertContains($user->avatar_color, [
+            'blue', 'cyan', 'green', 'magenta', 'orange',
+            'pine', 'purple', 'red', 'yellow',
+        ]);
+    }
 }

--- a/client/src/components/atoms/AvatarImage.vitest.spec.ts
+++ b/client/src/components/atoms/AvatarImage.vitest.spec.ts
@@ -6,18 +6,18 @@ import { describe, expect, it } from "vitest"
 
 installQuasarPlugin()
 describe("AvatarImage Component", () => {
-  const factory = (email: string) => {
+  const factory = (avatar_color: string) => {
     return mount(AvatarImage, {
       props: {
         user: {
-          email
+          avatar_color
         }
       }
     })
   }
 
-  it("returns a deterministic value", () => {
-    const wrapper = factory("test@meshresearch.net")
+  it("renders the color provided by the backend", () => {
+    const wrapper = factory("purple")
     expect((wrapper.vm as any).avatarSrc).toBe("/avatar/avatar-purple.png")
   })
 })

--- a/client/src/components/atoms/AvatarImage.vue
+++ b/client/src/components/atoms/AvatarImage.vue
@@ -9,7 +9,7 @@ import { graphql } from "src/graphql/generated"
 
 graphql(`
   fragment avatarImage on User {
-    email
+    avatar_color
   }
 `)
 </script>
@@ -24,35 +24,11 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const stringToInt = (s: string): number => {
-  let hash = 0
-  if (s.length === 0) return hash
-  for (let i = 0; i < s.length; i++) {
-    const chr = s.charCodeAt(i)
-    hash = (hash << 5) - hash + chr
-    hash |= 0 // Convert to 32bit integer
-  }
-  return hash
-}
-
-const colors = [
-  "blue",
-  "cyan",
-  "green",
-  "magenta",
-  "orange",
-  "pine",
-  "purple",
-  "red",
-  "yellow"
-]
-
 const avatarSrc = computed(() => {
-  if (!props.user.email) {
+  if (!props.user.avatar_color) {
     return ""
   }
-  const number = Math.abs(stringToInt(props.user.email)) % colors.length
-  return `/avatar/avatar-${colors[number]}.png`
+  return `/avatar/avatar-${props.user.avatar_color}.png`
 })
 </script>
 

--- a/client/src/components/atoms/ExportParticipantSelector.vitest.spec.ts
+++ b/client/src/components/atoms/ExportParticipantSelector.vitest.spec.ts
@@ -8,9 +8,9 @@ installQuasarPlugin()
 
 const mockSubmission: exportParticipantSelectorFragment = {
   commenters: [
-    { id: "1", display_label: "User One", email: "one@example.com" },
-    { id: "2", display_label: "User Two", email: "two@example.com" },
-    { id: "3", display_label: "User Three", email: "three@example.com" }
+    { id: "1", display_label: "User One", avatar_color: "blue" },
+    { id: "2", display_label: "User Two", avatar_color: "green" },
+    { id: "3", display_label: "User Three", avatar_color: "red" }
   ]
 }
 

--- a/client/src/components/atoms/UserListBasicItem.vue
+++ b/client/src/components/atoms/UserListBasicItem.vue
@@ -29,6 +29,7 @@ import type { avatarImageFragment } from "src/graphql/generated/graphql"
 interface User extends avatarImageFragment {
   name?: string | null
   username?: string | null
+  email?: string | null
 }
 
 interface Props {

--- a/client/src/components/molecules/UserListBasic.vue
+++ b/client/src/components/molecules/UserListBasic.vue
@@ -20,6 +20,7 @@ interface User extends avatarImageFragment {
   id?: string | null
   name?: string | null
   username?: string | null
+  email?: string | null
 }
 
 interface Props {

--- a/client/src/graphql/fragments.ts
+++ b/client/src/graphql/fragments.ts
@@ -28,6 +28,7 @@ export const _CURRENT_USER_FIELDS = gql`
     username
     name
     email
+    avatar_color
     email_verified_at
     roles {
       name
@@ -43,6 +44,7 @@ export const _RELATED_USER_FIELDS = gql`
     username
     name
     email
+    avatar_color
     staged
   }
 `

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -195,6 +195,7 @@ export const GET_USERS = gql`
         name
         username
         email
+        avatar_color
       }
     }
   }
@@ -204,9 +205,11 @@ export const GET_USERS = gql`
 export const GET_USER = gql`
   query getUser($id: ID) {
     user(id: $id) {
+      id
       username
       email
       name
+      avatar_color
       roles {
         name
       }
@@ -225,6 +228,7 @@ export const SEARCH_USERS = gql`
         username
         name
         email
+        avatar_color
       }
     }
   }

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -888,6 +888,7 @@ scalar Upload
 
 """A user account"""
 type User {
+  avatar_color: String! @deprecated(reason: "Temporary placeholder for stable avatar colors; will be removed when user-uploaded avatars are introduced.")
   created_at: DateTime!
   display_label: String
   email: String!

--- a/client/src/pages/Account/SettingsPage.vitest.spec.ts
+++ b/client/src/pages/Account/SettingsPage.vitest.spec.ts
@@ -57,6 +57,7 @@ describe("Settings page", () => {
           username: "test",
           name: "TestDoe",
           email: "test@example.com",
+          avatar_color: "blue",
           email_verified_at: null,
           roles: []
         }

--- a/client/src/pages/Admin/UserDetails.vitest.spec.ts
+++ b/client/src/pages/Admin/UserDetails.vitest.spec.ts
@@ -51,9 +51,11 @@ describe("User Details page mount", () => {
   it("reflects the lack of roles for a user with no assigned roles", async () => {
     getUserHandler.mockResolvedValue(
       mockUserResponse({
+        id: "1",
         username: "Username",
         email: "email",
         name: "Regular User",
+        avatar_color: "blue",
         roles: []
       })
     )
@@ -65,9 +67,11 @@ describe("User Details page mount", () => {
   it("reflects the role of an application administrator", async () => {
     getUserHandler.mockResolvedValue(
       mockUserResponse({
+        id: "2",
         name: "Application Admin User",
         username: "Username",
         email: "email",
+        avatar_color: "blue",
         roles: [
           {
             name: "Application Administrator"
@@ -85,9 +89,11 @@ describe("User Details page mount", () => {
   it("reflects the lack of display name for a user with no name", async () => {
     getUserHandler.mockResolvedValue(
       mockUserResponse({
+        id: "3",
         name: null,
         email: "email",
         username: "userWithNoName",
+        avatar_color: "blue",
         roles: []
       })
     )

--- a/client/src/pages/Admin/UsersIndex.vitest.spec.ts
+++ b/client/src/pages/Admin/UsersIndex.vitest.spec.ts
@@ -31,13 +31,15 @@ describe("User Index page mount", () => {
               id: "1",
               name: "test1",
               email: "test1@msu.edu",
-              username: "test1"
+              username: "test1",
+              avatar_color: "blue"
             },
             {
               id: "2",
               name: "test2",
               email: "test2@msu.edu",
-              username: "test2"
+              username: "test2",
+              avatar_color: "green"
             }
           ],
           paginatorInfo: {

--- a/client/src/pages/SubmissionDetails.vitest.spec.ts
+++ b/client/src/pages/SubmissionDetails.vitest.spec.ts
@@ -51,6 +51,7 @@ describe("submissions details page mount", () => {
         name: "Jest Submitter 1",
         username: "jestSubmitter1",
         email: "jestsubmitter1@msu.edu",
+        avatar_color: "blue",
         staged: null
       },
       {
@@ -60,6 +61,7 @@ describe("submissions details page mount", () => {
         name: "Jest Submitter 2",
         username: "jestSubmitter2",
         email: "jestsubmitter2@msu.edu",
+        avatar_color: "green",
         staged: null
       }
     ],
@@ -71,6 +73,7 @@ describe("submissions details page mount", () => {
         name: "Jest Reviewer 1",
         username: "jestReviewer1",
         email: "jestreviewer1@msu.edu",
+        avatar_color: "purple",
         staged: null
       },
       {
@@ -80,6 +83,7 @@ describe("submissions details page mount", () => {
         display_label: "Jest Reviewer 2",
         username: "jestReviewer2",
         email: "jestReviewer2@msu.edu",
+        avatar_color: "red",
         staged: true
       }
     ],
@@ -91,6 +95,7 @@ describe("submissions details page mount", () => {
         name: "Review Coordinator 1",
         username: "jestReviewCoordinator1",
         email: "jestcoordinator1@msu.edu",
+        avatar_color: "orange",
         staged: null
       }
     ]

--- a/client/src/pages/SubmissionExport.vitest.spec.ts
+++ b/client/src/pages/SubmissionExport.vitest.spec.ts
@@ -35,7 +35,7 @@ const mockExportOptionsResponse: { data: GetExportOptionsQuery } = {
         {
           id: "100",
           display_label: "Test User",
-          email: "test@example.com"
+          avatar_color: "purple"
         }
       ]
     }

--- a/client/src/use/user.vitest.spec.ts
+++ b/client/src/use/user.vitest.spec.ts
@@ -50,6 +50,7 @@ describe("useCurrentUser composable", () => {
           name: "Hello",
           email: "hello@example.com",
           username: "helloUser",
+          avatar_color: "blue",
           email_verified_at: "2021-08-14 02:26:32",
           highest_privileged_role: UserRoles.application_admin,
           roles: [{ name: "tester" }]


### PR DESCRIPTION
## Summary

Lands the server-computed `User.avatar_color` field as standalone prep work, ahead of PR #2286 (email redaction). Splits the avatar fix out of the security PR so each PR has a single concern and the security PR doesn't transiently break avatars on master.

Current state: avatars are colored by hashing the user's email client-side. That coupling means any future change to email visibility breaks avatar stability. Move the seed server-side now — independent value, no behavior change for end users.

### Changes

- **`User.avatar_color: String! @deprecated`** — server-computed color name (JS-parity hash of email, id fallback). Deprecated from day 1: short-lived placeholder until user-uploaded avatars land.
- **`AvatarImage.vue`** — drops local email hash, reads `avatar_color` directly.
- **`relatedUserFields` / `currentUserFields` / `GET_USER` / `GET_USERS` / `SEARCH_USERS`** — select `avatar_color`.
- **Test fixtures** updated to include the new field.

### Why this is independent of the email-redaction PR

- The hash uses email when present, falls back to id. Works whether email is public or redacted.
- Client switch from local hash → server field is a pure refactor while email is still selectable.
- After this lands, the email-redaction PR has no client-side avatar fallout to compensate for.

### Follow-up

- PR #2286 rebases onto master once this merges. The `avatar_color` chunks drop from its diff.

## Test plan

- [x] `lando backend-test` — `UserTest::testAvatarColorMatchesLegacyClientHash` verifies parity with the legacy client hash for a known email.
- [x] `lando client-yarn vitest run` — updated `AvatarImage` / `ExportParticipantSelector` / `SubmissionExport` / `UserDetails` / `UsersIndex` / `SubmissionDetails` / `SettingsPage` / `use/user` specs pass.
- [x] `lando client-yarn vue-tsc --noEmit` clean.
- [x] Manually verified avatar color for a known user is unchanged before/after.