### PR TITLE
ci(publish-docker): upload sourcemaps to GlitchTip

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -43,3 +43,30 @@ jobs:
         run: |
           gh release upload ${{ github.ref_name }} \
             ${{ steps.build-image.outputs.frontend-bundle }}
+      - name: Upload sourcemaps to GlitchTip
+        if: steps.build-image.outputs.frontend-bundle != ''
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}
+          SENTRY_URL: ${{ secrets.GLITCHTIP_URL }}
+          SENTRY_ORG: ${{ secrets.GLITCHTIP_ORG }}
+          SENTRY_PROJECT: ${{ secrets.GLITCHTIP_PROJECT }}
+          VERSION: ${{ steps.build-image.outputs.version }}
+          BUNDLE: ${{ steps.build-image.outputs.frontend-bundle }}
+        run: |
+          mkdir -p /tmp/sourcemap-extract
+          tar -xzf "$BUNDLE" -C /tmp/sourcemap-extract
+          SPA_DIR=$(find /tmp/sourcemap-extract -type d -name spa | head -n1)
+          if [ -z "$SPA_DIR" ]; then
+            echo "No spa directory found in bundle" >&2
+            exit 1
+          fi
+          MAP_COUNT=$(find "$SPA_DIR" -name '*.map' | wc -l)
+          echo "Found $MAP_COUNT sourcemap files under $SPA_DIR"
+          if [ "$MAP_COUNT" -eq 0 ]; then
+            echo "No sourcemaps to upload; skipping."
+            exit 0
+          fi
+          npx --yes @sentry/cli@^2 sourcemaps upload \
+            --release "pilcrow-client@${VERSION}" \
+            --url-prefix '~/' \
+            "$SPA_DIR"


### PR DESCRIPTION
## Summary
- After `build-image`, extract the existing `frontend-bundle.tar.gz` artifact and run `sentry-cli sourcemaps upload` against GlitchTip.
- Release name is `pilcrow-client@${VERSION}` to match the runtime release tag set in `client/src/boot/telemetry.ts` on the `feat/instrumentation` branch.
- Step is gated on `frontend-bundle` being present and short-circuits with a no-op when no `.map` files are found, so builds that disable sourcemap emission still pass.
- Runs on every push that publishes (master + tags), so edge images are also symbolicated.

## Required secrets
Configure in repo settings before merge:
- `GLITCHTIP_AUTH_TOKEN`
- `GLITCHTIP_URL`
- `GLITCHTIP_ORG`
- `GLITCHTIP_PROJECT`

Without these the step will fail at upload time; if you'd rather have it silently skip until secrets exist, add an `if:` gate on `secrets.GLITCHTIP_AUTH_TOKEN`.

## Notes
- `--url-prefix '~/'` matches assets regardless of host. Adjust if the SPA gets served under a subpath.
- Uses `npx @sentry/cli@^2` to avoid adding a new toolchain install step. Can be swapped for a pinned setup-action if the runner cold-start cost matters.
- Sourcemap *exposure* is still controlled at runtime by `EXPOSE_SOURCEMAPS` (unchanged). This PR only handles upload to the symbolication backend.

## Test plan
- [ ] Add the four `GLITCHTIP_*` secrets to the repo.
- [ ] Merge and watch the next master push; confirm the `Upload sourcemaps to GlitchTip` step succeeds and the release shows up in GlitchTip with artifacts.
- [ ] Trigger a client error in a deploy of that build and confirm the stack frames resolve to original source.