### PR TITLE
fix(ci): resolve VERSION and bundle layout for sourcemap upload

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -50,18 +50,14 @@ jobs:
           SENTRY_URL: ${{ secrets.GLITCHTIP_URL }}
           SENTRY_ORG: ${{ secrets.GLITCHTIP_ORG }}
           SENTRY_PROJECT: ${{ secrets.GLITCHTIP_PROJECT }}
-          VERSION: ${{ steps.build-image.outputs.version }}
           BUNDLE: ${{ steps.build-image.outputs.frontend-bundle }}
         run: |
+          VERSION=$(git describe --tags --match 'v*')
+          echo "Resolved release version: $VERSION"
           mkdir -p /tmp/sourcemap-extract
           tar -xzf "$BUNDLE" -C /tmp/sourcemap-extract
-          SPA_DIR=$(find /tmp/sourcemap-extract -type d -name spa | head -n1)
-          if [ -z "$SPA_DIR" ]; then
-            echo "No spa directory found in bundle" >&2
-            exit 1
-          fi
-          MAP_COUNT=$(find "$SPA_DIR" -name '*.map' | wc -l)
-          echo "Found $MAP_COUNT sourcemap files under $SPA_DIR"
+          MAP_COUNT=$(find /tmp/sourcemap-extract -name '*.map' | wc -l)
+          echo "Found $MAP_COUNT sourcemap files in bundle"
           if [ "$MAP_COUNT" -eq 0 ]; then
             echo "No sourcemaps to upload; skipping."
             exit 0
@@ -69,4 +65,4 @@ jobs:
           npx --yes @sentry/cli@^2 sourcemaps upload \
             --release "pilcrow-client@${VERSION}" \
             --url-prefix '~/' \
-            "$SPA_DIR"
+            /tmp/sourcemap-extract


### PR DESCRIPTION
## Summary
Follow-up fix to #2292. The first run on master failed at the new `Upload sourcemaps to GlitchTip` step for two reasons:

1. **`VERSION` env was empty.** The upstream `build-image` composite action exposes a `version` output in its `action.yaml`, but the `parse-build-output` command never actually calls `core.setOutput('version', ...)`. So `steps.build-image.outputs.version` resolves to an empty string and the release name came out as `pilcrow-client@`. Fixed by resolving `VERSION` locally with `git describe --tags --match 'v*'` — same call the upstream `setup` command uses, so it matches the version the Dockerfile receives at build time.

2. **`spa` directory lookup failed.** Inspected the `frontend-bundle.tar.gz` from the failed run; the tar root flattens `dist/spa` contents directly (`./assets/`, `./brand-images/`, ...), there is no `spa` subdirectory. The `find -name spa` returned empty and the step exited 1. Fixed by extracting and uploading the extract directory directly.

## Test plan
- [ ] Configure `GLITCHTIP_*` secrets in repo settings.
- [ ] Merge and watch the next master push: confirm `Resolved release version: vX.Y.Z-N-gSHA` appears in logs, sentry-cli reports map uploads, and the release shows up in GlitchTip.