### PR TITLE
fix(api): scope root submissions query to managed publications

### DIFF
--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -5,11 +5,13 @@ namespace App\Models;
 
 use App\Events\SubmissionStatusUpdated;
 use App\Http\Traits\CreatedUpdatedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Auth;
 use OwenIt\Auditing\Auditable as AuditableTrait;
 use OwenIt\Auditing\Contracts\Auditable;
 
@@ -44,6 +46,30 @@ class Submission extends Model implements Auditable
             $changes = $submission->getChanges();
             SubmissionStatusUpdated::dispatchIf(array_key_exists('status', $changes), $submission);
         });
+    }
+
+    /**
+     * Restrict the query to submissions in publications managed by the
+     * authenticated user:
+     *  - Application administrators manage all publications, so see all submissions.
+     *  - Users with any publication role (currently administrator or editor —
+     *    the only roles attached at the publication level) see submissions in
+     *    those publications.
+     *  - Anyone else sees nothing.
+     *
+     * Relies on the @guard directive to reject unauthenticated requests before
+     * this scope runs, so Auth::user() is always populated here.
+     */
+    public function scopeManagedPublicationSubmissions(Builder $query): Builder
+    {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+
+        if ($user->hasRole(Role::APPLICATION_ADMINISTRATOR)) {
+            return $query;
+        }
+
+        return $query->whereIn('publication_id', $user->publications()->pluck('publications.id'));
     }
 
     /**

--- a/backend/app/Policies/SubmissionPolicy.php
+++ b/backend/app/Policies/SubmissionPolicy.php
@@ -189,22 +189,6 @@ class SubmissionPolicy
     }
 
     /**
-     * View submission policy
-     *
-     * @param \App\Models\User $user
-     * @param \App\Models\Submission $submission
-     * @return \Illuminate\Auth\Access\Response|bool
-     */
-    public function viewAll(User $user, Submission $submission)
-    {
-        if ($this->checkAdminRoles($user, $submission->publication_id)) {
-            return true;
-        }
-
-        return Response::deny('UNAUTHORIZED');
-    }
-
-    /**
      * Update Submission Policy
      *
      * @param \App\Models\User $user

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -4,10 +4,10 @@ extend type Query {
     "Return a submission by ID"
     submission(id: ID @eq): Submission @find @can(ability: "view", find: "id")
 
-    "Return all submissions"
+    "Return submissions in publications managed by the current user (application admins see all; publication admins and editors see submissions in publications where they hold that role)."
     submissions: [Submission!]
-        @can(ability: "viewAll", query: true)
-        @paginate(defaultCount: 100)
+        @guard
+        @paginate(defaultCount: 100, scopes: ["managedPublicationSubmissions"])
         @orderBy(column: "created_at", direction: DESC)
 }
 

--- a/backend/tests/Api/SubmissionTest.php
+++ b/backend/tests/Api/SubmissionTest.php
@@ -1137,4 +1137,123 @@ class SubmissionTest extends ApiTestCase
         ];
         $response->assertJsonPath('data', $expected_data);
     }
+
+    /**
+     * A publication administrator should see only submissions in publications
+     * where they hold that role, and submissions in unrelated publications must
+     * not cause the whole query to fail.
+     *
+     * @return void
+     */
+    public function testPublicationAdminCanQuerySubmissionsAcrossPublications()
+    {
+        /** @var User $admin */
+        $admin = User::factory()->create();
+        $this->actingAs($admin);
+
+        $ownPublication = Publication::factory()
+            ->hasAttached($admin, [], 'publicationAdmins')
+            ->create();
+        $ownSubmission = Submission::factory()
+            ->for($ownPublication)
+            ->create(['title' => 'Own publication submission']);
+
+        $otherPublication = Publication::factory()->create();
+        Submission::factory()
+            ->for($otherPublication)
+            ->create(['title' => 'Other publication submission']);
+
+        $response = $this->graphQL(
+            'query GetSubmissions {
+                submissions {
+                    data {
+                        id
+                        title
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }'
+        );
+
+        $this->assertNull(
+            $response->json('errors'),
+            'Expected no authorization errors but got: ' . json_encode($response->json('errors'))
+        );
+        $response->assertJsonPath('data.submissions.paginatorInfo.total', 1);
+        $response->assertJsonPath('data.submissions.data.0.id', (string)$ownSubmission->id);
+    }
+
+    /**
+     * An application administrator should see every submission, regardless of
+     * publication membership.
+     *
+     * @return void
+     */
+    public function testApplicationAdminSeesAllSubmissions()
+    {
+        $this->beAppAdmin();
+
+        $pubA = Publication::factory()->create();
+        $pubB = Publication::factory()->create();
+        Submission::factory()->for($pubA)->create();
+        Submission::factory()->for($pubB)->create();
+
+        $response = $this->graphQL(
+            'query GetSubmissions {
+                submissions {
+                    data { id }
+                    paginatorInfo { total }
+                }
+            }'
+        );
+
+        $this->assertNull(
+            $response->json('errors'),
+            'Expected no authorization errors but got: ' . json_encode($response->json('errors'))
+        );
+        $response->assertJsonPath('data.submissions.paginatorInfo.total', 2);
+    }
+
+    /**
+     * An editor should see only submissions in publications where they hold
+     * the editor role.
+     *
+     * @return void
+     */
+    public function testEditorSeesSubmissionsOnlyInOwnPublications()
+    {
+        /** @var User $editor */
+        $editor = User::factory()->create();
+        $this->actingAs($editor);
+
+        $ownPublication = Publication::factory()
+            ->hasAttached($editor, [], 'editors')
+            ->create();
+        $ownSubmission = Submission::factory()
+            ->for($ownPublication)
+            ->create(['title' => 'Editor publication submission']);
+
+        $otherPublication = Publication::factory()->create();
+        Submission::factory()
+            ->for($otherPublication)
+            ->create(['title' => 'Unrelated publication submission']);
+
+        $response = $this->graphQL(
+            'query GetSubmissions {
+                submissions {
+                    data { id title }
+                    paginatorInfo { total }
+                }
+            }'
+        );
+
+        $this->assertNull(
+            $response->json('errors'),
+            'Expected no authorization errors but got: ' . json_encode($response->json('errors'))
+        );
+        $response->assertJsonPath('data.submissions.paginatorInfo.total', 1);
+        $response->assertJsonPath('data.submissions.data.0.id', (string)$ownSubmission->id);
+    }
 }

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -561,7 +561,9 @@ type Query {
   """Return a submission by ID"""
   submission(id: ID): Submission
 
-  """Return all submissions"""
+  """
+  Return submissions in publications managed by the current user (application admins see all; publication admins and editors see submissions in publications where they hold that role).
+  """
   submissions(
     """Limits number of fetched items."""
     first: Int! = 100


### PR DESCRIPTION
## Summary
- The root `submissions` GraphQL query was gated with `@can(ability: "viewAll", query: true)`. `@can(query: true)` runs `Submission::query()->get()` and invokes the policy per row, so as soon as a submission exists in a publication the current user does not administer, Lighthouse threw `UNAUTHORIZED` for the whole query.
- Result: publication administrators and editors could not load the admin/editor `SubmissionTable` introduced in #2020 once submissions existed outside their publications. Only application administrators reliably got data back.
- Replace the per-row gate with an Eloquent scope `Submission::scopeManagedPublicationSubmissions`. App admins return the unfiltered builder; everyone else is filtered to submissions whose `publication_id` is in `$user->publications` (the publication-level pivot only ever holds publication administrator / editor roles). `@guard` keeps anonymous traffic out, so the scope can assume `Auth::user()` is populated.
- Removes the now-unused `SubmissionPolicy::viewAll` method.

## Test plan
- [x] `lando backend-test --filter "Tests\\Api\\SubmissionTest"` — 130 passed.
- [x] `lando backend-test --filter "Tests\\Api"` — 307 passed.
- [x] `composer lint` — clean.
- [x] `yarn lint` (client) — clean for changed files; pre-existing prettier warning in `client/src/telemetry/config.ts` is unrelated.
- [x] Manual: as a publication administrator on one publication, load the Dashboard/Submissions/Reviews pages with submissions also present in unrelated publications, and confirm the admin/editor table renders only the managed publication's submissions.
- [x] Manual: as a plain submitter/reviewer, confirm the admin/editor table is hidden (empty result, no error) and personal submission lists still load.
- [x] Manual: as an application administrator, confirm every submission still appears.