### PR TITLE
feat(telemetry): emit aggregate application metrics via Sentry

### DIFF
--- a/.lando/default.conf.tpl
+++ b/.lando/default.conf.tpl
@@ -38,8 +38,19 @@ server {
         try_files /dev/null @backend;
     }
 
+    # SPA navigation (Accept: text/html) goes to Laravel so index.blade.php can
+    # inject runtime globals (__TELEMETRY_CONFIG, __APP_BANNER).
+    # Everything else (JS modules, HMR, asset files) proxies to the vite dev server.
     location / {
+        if ($http_accept ~* "text/html") {
+            rewrite ^ /__spa last;
+        }
         try_files /dev/null @vite;
+    }
+
+    location /__spa {
+        internal;
+        try_files /dev/null @backend;
     }
 
     location /graphql {

--- a/backend/app/Providers/TelemetryServiceProvider.php
+++ b/backend/app/Providers/TelemetryServiceProvider.php
@@ -4,14 +4,30 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\Publication;
+use App\Models\Submission;
+use App\Telemetry\Metrics;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class TelemetryServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->app->singleton(Metrics::class, function (Application $app): Metrics {
+            $enabled = (bool) config('app.telemetry.enabled')
+                && filled(config('app.telemetry.dsn'));
+
+            return new Metrics($enabled);
+        });
+
         if (filled(config('app.telemetry.release'))) {
             return;
         }
@@ -30,6 +46,8 @@ class TelemetryServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->registerMetricEmitters();
+
         if (! config('app.telemetry.enabled') || ! filled(config('app.telemetry.dsn'))) {
             return;
         }
@@ -51,6 +69,39 @@ class TelemetryServiceProvider extends ServiceProvider
                     $scope->setTag('user.roles', $user->getRoleNames()->implode(','));
                 }
             }
+        });
+    }
+
+    /**
+     * Aggregate counters only. No user ids, emails, or other PII in attributes.
+     * Wired even when telemetry is disabled — Metrics short-circuits to no-op.
+     */
+    private function registerMetricEmitters(): void
+    {
+        $metrics = fn (): Metrics => $this->app->make(Metrics::class);
+
+        Event::listen(Login::class, function () use ($metrics): void {
+            $metrics()->count('auth.login_success');
+        });
+
+        Event::listen(Failed::class, function () use ($metrics): void {
+            $metrics()->count('auth.login_failed');
+        });
+
+        Event::listen(Registered::class, function () use ($metrics): void {
+            $metrics()->count('auth.signup');
+        });
+
+        Event::listen(Verified::class, function () use ($metrics): void {
+            $metrics()->count('auth.email_verified');
+        });
+
+        Publication::created(function () use ($metrics): void {
+            $metrics()->count('publication.created');
+        });
+
+        Submission::created(function () use ($metrics): void {
+            $metrics()->count('submission.created');
         });
     }
 }

--- a/backend/app/Telemetry/Metrics.php
+++ b/backend/app/Telemetry/Metrics.php
@@ -1,10 +1,10 @@
 <?php
-
 declare(strict_types=1);
 
 namespace App\Telemetry;
 
 use Sentry\Unit;
+use function Sentry\traceMetrics;
 
 /**
  * Thin wrapper around the Sentry PHP SDK trace-metrics module. All methods are
@@ -12,10 +12,16 @@ use Sentry\Unit;
  */
 class Metrics
 {
+    /**
+     * @param bool $enabled when false, all emit methods short-circuit to no-ops
+     */
     public function __construct(private readonly bool $enabled)
     {
     }
 
+    /**
+     * @return bool true when telemetry is configured and metrics will be emitted
+     */
     public function isEnabled(): bool
     {
         return $this->enabled;
@@ -34,7 +40,7 @@ class Metrics
             return;
         }
 
-        \Sentry\traceMetrics()->count($name, $value, $attributes, $unit);
+        traceMetrics()->count($name, $value, $attributes, $unit);
     }
 
     /**
@@ -50,7 +56,7 @@ class Metrics
             return;
         }
 
-        \Sentry\traceMetrics()->gauge($name, $value, $attributes, $unit);
+        traceMetrics()->gauge($name, $value, $attributes, $unit);
     }
 
     /**
@@ -66,15 +72,18 @@ class Metrics
             return;
         }
 
-        \Sentry\traceMetrics()->distribution($name, $value, $attributes, $unit);
+        traceMetrics()->distribution($name, $value, $attributes, $unit);
     }
 
+    /**
+     * Flush any buffered metrics to the transport. Safe to call when disabled.
+     */
     public function flush(): void
     {
         if (! $this->enabled) {
             return;
         }
 
-        \Sentry\traceMetrics()->flush();
+        traceMetrics()->flush();
     }
 }

--- a/backend/app/Telemetry/Metrics.php
+++ b/backend/app/Telemetry/Metrics.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Telemetry;
+
+use Sentry\Unit;
+
+/**
+ * Thin wrapper around the Sentry PHP SDK trace-metrics module. All methods are
+ * no-ops when telemetry is disabled, so call sites do not need feature flags.
+ */
+class Metrics
+{
+    public function __construct(private readonly bool $enabled)
+    {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function count(
+        string $name,
+        int|float $value = 1,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        if (! $this->enabled) {
+            return;
+        }
+
+        \Sentry\traceMetrics()->count($name, $value, $attributes, $unit);
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function gauge(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        if (! $this->enabled) {
+            return;
+        }
+
+        \Sentry\traceMetrics()->gauge($name, $value, $attributes, $unit);
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function distribution(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        if (! $this->enabled) {
+            return;
+        }
+
+        \Sentry\traceMetrics()->distribution($name, $value, $attributes, $unit);
+    }
+
+    public function flush(): void
+    {
+        if (! $this->enabled) {
+            return;
+        }
+
+        \Sentry\traceMetrics()->flush();
+    }
+}

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -28,8 +28,6 @@ return [
         'environment' => env('TELEMETRY_ENVIRONMENT', env('APP_ENV', 'production')),
         'release' => env('TELEMETRY_RELEASE'),
         'traces_sample_rate' => (float) env('TELEMETRY_TRACES_SAMPLE_RATE', 0.0),
-        'replays_session_sample_rate' => (float) env('TELEMETRY_REPLAYS_SESSION_SAMPLE_RATE', 0.0),
-        'replays_on_error_sample_rate' => (float) env('TELEMETRY_REPLAYS_ON_ERROR_SAMPLE_RATE', 0.0),
     ],
 
     /*

--- a/backend/resources/views/index.blade.php
+++ b/backend/resources/views/index.blade.php
@@ -31,8 +31,6 @@
       'dsn' => config('app.telemetry.enabled') ? (config('app.telemetry.public_dsn') ?? config('app.telemetry.dsn')) : null,
       'environment' => config('app.telemetry.environment'),
       'tracesSampleRate' => (float) config('app.telemetry.traces_sample_rate'),
-      'replaysSessionSampleRate' => (float) config('app.telemetry.replays_session_sample_rate'),
-      'replaysOnErrorSampleRate' => (float) config('app.telemetry.replays_on_error_sample_rate'),
     ])
     window.__TELEMETRY_CONFIG = @json($telemetry);
   </script>

--- a/backend/tests/Feature/TelemetryInjectionTest.php
+++ b/backend/tests/Feature/TelemetryInjectionTest.php
@@ -27,8 +27,6 @@ class TelemetryInjectionTest extends TestCase
             'app.telemetry.dsn' => 'https://public@example.ingest.sentry.io/1',
             'app.telemetry.environment' => 'staging',
             'app.telemetry.traces_sample_rate' => 0.25,
-            'app.telemetry.replays_session_sample_rate' => 0.0,
-            'app.telemetry.replays_on_error_sample_rate' => 0.1,
         ]);
 
         $response = $this->get('/');
@@ -38,7 +36,7 @@ class TelemetryInjectionTest extends TestCase
         $response->assertSee('"environment":"staging"', false);
         $response->assertDontSee('"release"', false);
         $response->assertSee('"tracesSampleRate":0.25', false);
-        $response->assertSee('"replaysOnErrorSampleRate":0.1', false);
+        $response->assertDontSee('replays', false);
     }
 
     public function testTelemetryDsnSuppressedWhenDisabledEvenIfSet(): void

--- a/backend/tests/Feature/TelemetryMetricsBindingTest.php
+++ b/backend/tests/Feature/TelemetryMetricsBindingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Tests\Feature;

--- a/backend/tests/Feature/TelemetryMetricsBindingTest.php
+++ b/backend/tests/Feature/TelemetryMetricsBindingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Telemetry\Metrics;
+use Tests\TestCase;
+
+class TelemetryMetricsBindingTest extends TestCase
+{
+    public function testMetricsDisabledByDefault(): void
+    {
+        config([
+            'app.telemetry.enabled' => false,
+            'app.telemetry.dsn' => null,
+        ]);
+
+        $metrics = $this->app->make(Metrics::class);
+        $this->assertFalse($metrics->isEnabled());
+    }
+
+    public function testMetricsDisabledWhenDsnMissing(): void
+    {
+        config([
+            'app.telemetry.enabled' => true,
+            'app.telemetry.dsn' => null,
+        ]);
+
+        $this->app->forgetInstance(Metrics::class);
+        $metrics = $this->app->make(Metrics::class);
+        $this->assertFalse($metrics->isEnabled());
+    }
+
+    public function testMetricsEnabledWithDsnAndFlag(): void
+    {
+        config([
+            'app.telemetry.enabled' => true,
+            'app.telemetry.dsn' => 'https://public@sentry.example.com/1',
+        ]);
+
+        $this->app->forgetInstance(Metrics::class);
+        $metrics = $this->app->make(Metrics::class);
+        $this->assertTrue($metrics->isEnabled());
+    }
+
+    public function testCountAndFlushAreNoOpsWhenDisabled(): void
+    {
+        config([
+            'app.telemetry.enabled' => false,
+            'app.telemetry.dsn' => null,
+        ]);
+
+        $this->app->forgetInstance(Metrics::class);
+        $metrics = $this->app->make(Metrics::class);
+
+        // Should not throw even though Sentry SDK is not initialized.
+        $metrics->count('test.event');
+        $metrics->gauge('test.gauge', 1);
+        $metrics->distribution('test.distribution', 1.5);
+        $metrics->flush();
+
+        $this->assertTrue(true);
+    }
+}

--- a/backend/tests/Feature/TelemetryMetricsEmissionTest.php
+++ b/backend/tests/Feature/TelemetryMetricsEmissionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Publication;
+use App\Models\Submission;
+use App\Models\User;
+use App\Telemetry\Metrics;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Sentry\Unit;
+use Tests\TestCase;
+
+class TelemetryMetricsEmissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FakeMetrics $metrics;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->metrics = new FakeMetrics();
+        $this->app->instance(Metrics::class, $this->metrics);
+    }
+
+    public function testLoginEventEmitsSuccessCounter(): void
+    {
+        $user = User::factory()->create();
+        Event::dispatch(new Login('web', $user, false));
+
+        $this->assertSame(1, $this->metrics->totalFor('auth.login_success'));
+    }
+
+    public function testFailedEventEmitsFailureCounter(): void
+    {
+        Event::dispatch(new Failed('web', null, ['email' => 'x@example.test']));
+
+        $this->assertSame(1, $this->metrics->totalFor('auth.login_failed'));
+    }
+
+    public function testRegisteredEventEmitsSignupCounter(): void
+    {
+        $user = User::factory()->create();
+        Event::dispatch(new Registered($user));
+
+        $this->assertSame(1, $this->metrics->totalFor('auth.signup'));
+    }
+
+    public function testVerifiedEventEmitsEmailVerifiedCounter(): void
+    {
+        $user = User::factory()->create();
+        Event::dispatch(new Verified($user));
+
+        $this->assertSame(1, $this->metrics->totalFor('auth.email_verified'));
+    }
+
+    public function testPublicationCreatedEmitsCounter(): void
+    {
+        Publication::factory()->create();
+
+        $this->assertSame(1, $this->metrics->totalFor('publication.created'));
+    }
+
+    public function testSubmissionCreatedEmitsCounter(): void
+    {
+        Submission::factory()->create();
+
+        $this->assertSame(1, $this->metrics->totalFor('submission.created'));
+    }
+
+    public function testCountersCarryNoUserIdentifiers(): void
+    {
+        $user = User::factory()->create();
+        Event::dispatch(new Login('web', $user, false));
+        Event::dispatch(new Registered($user));
+
+        foreach ($this->metrics->calls as $call) {
+            $this->assertSame([], $call['attributes'], "metric {$call['name']} leaked attributes");
+        }
+    }
+}
+
+class FakeMetrics extends Metrics
+{
+    /** @var array<int, array{name: string, value: int|float, attributes: array<string,mixed>}> */
+    public array $calls = [];
+
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
+    public function count(
+        string $name,
+        int|float $value = 1,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    public function gauge(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    public function distribution(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    public function flush(): void
+    {
+    }
+
+    public function totalFor(string $name): int
+    {
+        return count(array_filter($this->calls, fn ($c) => $c['name'] === $name));
+    }
+}

--- a/backend/tests/Feature/TelemetryMetricsEmissionTest.php
+++ b/backend/tests/Feature/TelemetryMetricsEmissionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Tests\Feature;
@@ -14,7 +13,7 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use Sentry\Unit;
+use Tests\Support\FakeMetrics;
 use Tests\TestCase;
 
 class TelemetryMetricsEmissionTest extends TestCase
@@ -85,52 +84,5 @@ class TelemetryMetricsEmissionTest extends TestCase
         foreach ($this->metrics->calls as $call) {
             $this->assertSame([], $call['attributes'], "metric {$call['name']} leaked attributes");
         }
-    }
-}
-
-class FakeMetrics extends Metrics
-{
-    /** @var array<int, array{name: string, value: int|float, attributes: array<string,mixed>}> */
-    public array $calls = [];
-
-    public function __construct()
-    {
-        parent::__construct(true);
-    }
-
-    public function count(
-        string $name,
-        int|float $value = 1,
-        array $attributes = [],
-        ?Unit $unit = null
-    ): void {
-        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
-    }
-
-    public function gauge(
-        string $name,
-        int|float $value,
-        array $attributes = [],
-        ?Unit $unit = null
-    ): void {
-        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
-    }
-
-    public function distribution(
-        string $name,
-        int|float $value,
-        array $attributes = [],
-        ?Unit $unit = null
-    ): void {
-        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
-    }
-
-    public function flush(): void
-    {
-    }
-
-    public function totalFor(string $name): int
-    {
-        return count(array_filter($this->calls, fn ($c) => $c['name'] === $name));
     }
 }

--- a/backend/tests/Support/FakeMetrics.php
+++ b/backend/tests/Support/FakeMetrics.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Telemetry\Metrics;
+use Sentry\Unit;
+
+/**
+ * Test double that records emit calls in-memory instead of forwarding to the
+ * Sentry SDK. Bind into the container with `$this->app->instance(Metrics::class, new FakeMetrics())`.
+ */
+class FakeMetrics extends Metrics
+{
+    /**
+     * @var array<int, array{name: string, value: int|float, attributes: array<string,mixed>}>
+     */
+    public array $calls = [];
+
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function count(
+        string $name,
+        int|float $value = 1,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        unset($unit);
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function gauge(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        unset($unit);
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    /**
+     * @param array<string, int|float|string|bool> $attributes
+     */
+    public function distribution(
+        string $name,
+        int|float $value,
+        array $attributes = [],
+        ?Unit $unit = null
+    ): void {
+        unset($unit);
+        $this->calls[] = ['name' => $name, 'value' => $value, 'attributes' => $attributes];
+    }
+
+    public function flush(): void
+    {
+    }
+
+    /**
+     * Return the number of times `count()` was invoked with the given metric name.
+     */
+    public function totalFor(string $name): int
+    {
+        return count(array_filter($this->calls, fn($c) => $c['name'] === $name));
+    }
+}

--- a/backend/tests/Unit/Telemetry/MetricsTest.php
+++ b/backend/tests/Unit/Telemetry/MetricsTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Telemetry;
+
+use App\Telemetry\Metrics;
+use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+use Sentry\Metrics\MetricsAggregator;
+use Sentry\SentrySdk;
+use Sentry\Unit;
+
+/**
+ * Exercises the conditional gate in App\Telemetry\Metrics. Verifies disabled
+ * mode short-circuits without touching the SDK and enabled mode forwards to the
+ * Sentry TraceMetrics aggregator. Inspects the shared singleton aggregator
+ * buffer directly because the wrapper calls the global Sentry\traceMetrics()
+ * helper and cannot accept an injected dispatcher.
+ */
+class MetricsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetAggregatorBuffer();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetAggregatorBuffer();
+        parent::tearDown();
+    }
+
+    public function testIsEnabledReflectsConstructorFlag(): void
+    {
+        $this->assertTrue((new Metrics(true))->isEnabled());
+        $this->assertFalse((new Metrics(false))->isEnabled());
+    }
+
+    public function testDisabledCountDoesNotBufferMetric(): void
+    {
+        (new Metrics(false))->count('disabled.count', 5, ['k' => 'v'], Unit::second());
+
+        $this->assertNull($this->aggregatorBuffer());
+    }
+
+    public function testDisabledGaugeDoesNotBufferMetric(): void
+    {
+        (new Metrics(false))->gauge('disabled.gauge', 1.5);
+
+        $this->assertNull($this->aggregatorBuffer());
+    }
+
+    public function testDisabledDistributionDoesNotBufferMetric(): void
+    {
+        (new Metrics(false))->distribution('disabled.distribution', 2.0);
+
+        $this->assertNull($this->aggregatorBuffer());
+    }
+
+    public function testDisabledFlushIsNoOp(): void
+    {
+        (new Metrics(false))->flush();
+
+        $this->assertNull($this->aggregatorBuffer());
+    }
+
+    public function testEnabledCountForwardsToSentryAggregator(): void
+    {
+        (new Metrics(true))->count('enabled.count', 3, ['region' => 'us-east'], Unit::second());
+
+        $buffer = $this->aggregatorBuffer();
+        $this->assertNotNull($buffer);
+        $this->assertSame(1, count($buffer));
+    }
+
+    public function testEnabledGaugeForwardsToSentryAggregator(): void
+    {
+        (new Metrics(true))->gauge('enabled.gauge', 7.5);
+
+        $buffer = $this->aggregatorBuffer();
+        $this->assertNotNull($buffer);
+        $this->assertSame(1, count($buffer));
+    }
+
+    public function testEnabledDistributionForwardsToSentryAggregator(): void
+    {
+        (new Metrics(true))->distribution('enabled.distribution', 12.0);
+
+        $buffer = $this->aggregatorBuffer();
+        $this->assertNotNull($buffer);
+        $this->assertSame(1, count($buffer));
+    }
+
+    public function testEnabledEmitsAccumulateAcrossCalls(): void
+    {
+        $metrics = new Metrics(true);
+        $metrics->count('enabled.multi', 1);
+        $metrics->gauge('enabled.multi', 2);
+        $metrics->distribution('enabled.multi', 3);
+
+        $this->assertSame(3, count($this->aggregatorBuffer()));
+    }
+
+    public function testEnabledFlushDrainsBufferedMetrics(): void
+    {
+        $metrics = new Metrics(true);
+        $metrics->count('enabled.flush', 1);
+
+        $this->assertSame(1, count($this->aggregatorBuffer()));
+
+        $metrics->flush();
+
+        $this->assertTrue($this->aggregatorBuffer()->isEmpty());
+    }
+
+    private function aggregator(): MetricsAggregator
+    {
+        return SentrySdk::getCurrentRuntimeContext()->getMetricsAggregator();
+    }
+
+    private function aggregatorBuffer(): mixed
+    {
+        $agg = $this->aggregator();
+        $prop = (new ReflectionObject($agg))->getProperty('metrics');
+        $prop->setAccessible(true);
+        return $prop->getValue($agg);
+    }
+
+    private function resetAggregatorBuffer(): void
+    {
+        $agg = $this->aggregator();
+        $prop = (new ReflectionObject($agg))->getProperty('metrics');
+        $prop->setAccessible(true);
+        $prop->setValue($agg, null);
+    }
+}

--- a/backend/tests/Unit/Telemetry/MetricsTest.php
+++ b/backend/tests/Unit/Telemetry/MetricsTest.php
@@ -124,6 +124,7 @@ class MetricsTest extends TestCase
         $agg = $this->aggregator();
         $prop = (new ReflectionObject($agg))->getProperty('metrics');
         $prop->setAccessible(true);
+
         return $prop->getValue($agg);
     }
 

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@apollo/client": "^3.7.2",
     "@quasar/extras": "^1.15.8",
     "@quasar/quasar-ui-qiconpicker": "^2.0.6",
-    "@sentry/vue": "^8.55.0",
+    "@sentry/vue": "^10.25.0",
     "@tiptap/extension-highlight": "^2.0.3",
     "@tiptap/extension-link": "^2.0.3",
     "@tiptap/extension-placeholder": "^2.0.3",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,5 +1,3 @@
 <template>
   <router-view />
 </template>
-
-<script setup lang="ts"></script>

--- a/client/src/boot/telemetry.ts
+++ b/client/src/boot/telemetry.ts
@@ -18,17 +18,8 @@ export default defineBoot(async ({ app, router }) => {
     environment: cfg.environment ?? undefined,
     release,
     tracesSampleRate: cfg.tracesSampleRate,
-    replaysSessionSampleRate: cfg.replaysSessionSampleRate,
-    replaysOnErrorSampleRate: cfg.replaysOnErrorSampleRate,
     sendDefaultPii: false,
-    integrations: [
-      Sentry.browserTracingIntegration({ router }),
-      Sentry.replayIntegration({
-        maskAllText: true,
-        maskAllInputs: true,
-        blockAllMedia: true
-      })
-    ],
+    integrations: [Sentry.browserTracingIntegration({ router })],
     beforeSend(event) {
       if (event.request) event.request = scrub(event.request)
       if (event.extra) event.extra = scrub(event.extra)

--- a/client/src/telemetry/config.ts
+++ b/client/src/telemetry/config.ts
@@ -3,8 +3,6 @@ export type TelemetryConfig = {
   dsn: string | null
   environment: string | null
   tracesSampleRate: number
-  replaysSessionSampleRate: number
-  replaysOnErrorSampleRate: number
 }
 
 declare global {
@@ -17,12 +15,7 @@ declare global {
 // content (manuscript text, review comments). Field-level redaction is
 // preferred over dropping entire mutation variables so non-sensitive context
 // like ids, ranges, and style criteria stays available for triage.
-const SENSITIVE_KEYS = new Set([
-  "password",
-  "token",
-  "code",
-  "content"
-])
+const SENSITIVE_KEYS = new Set(["password", "token", "code", "content"])
 
 export function readTelemetryConfig(): TelemetryConfig | null {
   if (typeof window === "undefined") return null

--- a/client/src/telemetry/config.vitest.spec.ts
+++ b/client/src/telemetry/config.vitest.spec.ts
@@ -21,9 +21,7 @@ describe("readTelemetryConfig", () => {
       enabled: false,
       dsn: "https://k@example.ingest.sentry.io/1",
       environment: "production",
-      tracesSampleRate: 0,
-      replaysSessionSampleRate: 0,
-      replaysOnErrorSampleRate: 0
+      tracesSampleRate: 0
     })
     expect(readTelemetryConfig()).toBeNull()
   })
@@ -33,9 +31,7 @@ describe("readTelemetryConfig", () => {
       enabled: true,
       dsn: null,
       environment: "production",
-      tracesSampleRate: 0,
-      replaysSessionSampleRate: 0,
-      replaysOnErrorSampleRate: 0
+      tracesSampleRate: 0
     })
     expect(readTelemetryConfig()).toBeNull()
   })
@@ -45,9 +41,7 @@ describe("readTelemetryConfig", () => {
       enabled: true,
       dsn: "https://k@example.ingest.sentry.io/1",
       environment: "staging",
-      tracesSampleRate: 0.25,
-      replaysSessionSampleRate: 0,
-      replaysOnErrorSampleRate: 0.1
+      tracesSampleRate: 0.25
     }
     setCfg(cfg)
     expect(readTelemetryConfig()).toEqual(cfg)

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1756,59 +1756,59 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@sentry-internal/browser-utils@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.55.2.tgz#3463115ac048813d71565c6fa2a48e6d60f15e8b"
-  integrity sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==
+"@sentry-internal/browser-utils@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz#cbe105889a22afba5974b91050feb80a2d521f9f"
+  integrity sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==
   dependencies:
-    "@sentry/core" "8.55.2"
+    "@sentry/core" "10.53.1"
 
-"@sentry-internal/feedback@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.55.2.tgz#16608bf305beb840b751f63473558cb57e9c9503"
-  integrity sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==
+"@sentry-internal/feedback@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-10.53.1.tgz#0bbd1cd80d0a07f01afec70cc356971be9871ae6"
+  integrity sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==
   dependencies:
-    "@sentry/core" "8.55.2"
+    "@sentry/core" "10.53.1"
 
-"@sentry-internal/replay-canvas@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.55.2.tgz#66138ae5e31c8e77a72ceab12673bfd7ae99dd26"
-  integrity sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==
+"@sentry-internal/replay-canvas@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz#55ead9251c047fcb95bdd5c58649b3bc18ae8b12"
+  integrity sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==
   dependencies:
-    "@sentry-internal/replay" "8.55.2"
-    "@sentry/core" "8.55.2"
+    "@sentry-internal/replay" "10.53.1"
+    "@sentry/core" "10.53.1"
 
-"@sentry-internal/replay@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.55.2.tgz#c00cfa8117a6bad93f5522671049760e3780d0c8"
-  integrity sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==
+"@sentry-internal/replay@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-10.53.1.tgz#d4bd3c119e50b56f96a22a8d462eff83f8a92672"
+  integrity sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==
   dependencies:
-    "@sentry-internal/browser-utils" "8.55.2"
-    "@sentry/core" "8.55.2"
+    "@sentry-internal/browser-utils" "10.53.1"
+    "@sentry/core" "10.53.1"
 
-"@sentry/browser@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.55.2.tgz#95eff656e5a61f4a22605f88c03746c20c51cf47"
-  integrity sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==
+"@sentry/browser@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.53.1.tgz#db8dbbf4fc752acec9fec5073a7105a2b0f58f97"
+  integrity sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==
   dependencies:
-    "@sentry-internal/browser-utils" "8.55.2"
-    "@sentry-internal/feedback" "8.55.2"
-    "@sentry-internal/replay" "8.55.2"
-    "@sentry-internal/replay-canvas" "8.55.2"
-    "@sentry/core" "8.55.2"
+    "@sentry-internal/browser-utils" "10.53.1"
+    "@sentry-internal/feedback" "10.53.1"
+    "@sentry-internal/replay" "10.53.1"
+    "@sentry-internal/replay-canvas" "10.53.1"
+    "@sentry/core" "10.53.1"
 
-"@sentry/core@8.55.2":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.55.2.tgz#1a841aefc9b96f7a8a05c30162fa6ebc7e1dc47a"
-  integrity sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==
+"@sentry/core@10.53.1":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.53.1.tgz#68bed0e5857be6a8d5009268337c4153ab87514d"
+  integrity sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==
 
-"@sentry/vue@^8.55.0":
-  version "8.55.2"
-  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-8.55.2.tgz#cc2193100a73f43af2406cbf8c15c6782f79f684"
-  integrity sha512-ksma1z5VbNt1tOyBVAA9giocF+KZrT3uxm6VyCxWJKvKkgvkYs49DXwsRL5n8Qf64EZ+dCG2/IUmV21dulcV8A==
+"@sentry/vue@^10.25.0":
+  version "10.53.1"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-10.53.1.tgz#bb0fad56bb239c308a8d63ec505fefb56266af61"
+  integrity sha512-s5TeBXpQogrjS+Oom3y2wfOrju4RV2+E4wQoFt/TQPyACqvQHIcmapHcxk4bAx8jggRetmM+KwpMNgl6HJB0tg==
   dependencies:
-    "@sentry/browser" "8.55.2"
-    "@sentry/core" "8.55.2"
+    "@sentry/browser" "10.53.1"
+    "@sentry/core" "10.53.1"
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary

- Adds `App\Telemetry\Metrics`: thin wrapper around Sentry's PHP trace-metrics module. No-op when telemetry disabled, so call sites need no feature flags.
- Wires aggregate counters in `TelemetryServiceProvider::boot()` for core usage signals:
  - `auth.login_success`, `auth.login_failed`, `auth.signup`, `auth.email_verified`
  - `publication.created`, `submission.created`
- Counters carry **no PII or user identifiers** — counts only.
- Frontend: bumps `@sentry/vue` to ^10.25.0 for the new metrics API; removes scaffolded PostHog/Analytics module and Session Replay config.
- Dev nginx: SPA-navigation rewrite so Laravel can inject `__TELEMETRY_CONFIG` at HTML load time.

## Test plan

- [x] `lando backend-test` — 467 passed (937 assertions)
- [x] `TelemetryMetricsBindingTest` — Metrics binding enabled/disabled logic
- [x] `TelemetryMetricsEmissionTest` — each event fires its counter once, no attributes leaked
- [x] `lando client-yarn vitest run src/telemetry/config.vitest.spec.ts` — 7 passed
- [x] `vue-tsc` clean
- [x] Manual: enable telemetry locally, hit login/signup/publication-create paths, verify counters land in Sentry