### PR TITLE
fix(publication): scope list query to visible publications

### DIFF
--- a/backend/app/Models/Publication.php
+++ b/backend/app/Models/Publication.php
@@ -65,6 +65,33 @@ class Publication extends BaseModel
     }
 
     /**
+     * Scope to publications the current user is allowed to see.
+     *
+     * Guests see only publicly visible publications. Application
+     * administrators see everything. Other authenticated users see publicly
+     * visible publications plus any private publication they hold a role on.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisibleToCurrentUser($query)
+    {
+        /** @var \App\Models\User|null $user */
+        $user = auth()->user();
+
+        if ($user && $user->hasRole(Role::APPLICATION_ADMINISTRATOR)) {
+            return $query;
+        }
+
+        return $query->where(function ($q) use ($user) {
+            $q->where('is_publicly_visible', true);
+            if ($user) {
+                $q->orWhereIn('id', $user->publications()->select('publications.id'));
+            }
+        });
+    }
+
+    /**
      * Users that belong to a publication
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany

--- a/backend/app/Policies/PublicationPolicy.php
+++ b/backend/app/Policies/PublicationPolicy.php
@@ -58,6 +58,9 @@ class PublicationPolicy
         if ($publication->is_publicly_visible) {
             return true;
         }
+        if ($user === null) {
+            return false;
+        }
         if ($user->hasRole(Role::APPLICATION_ADMINISTRATOR)) {
             return true;
         }

--- a/backend/graphql/publication.graphql
+++ b/backend/graphql/publication.graphql
@@ -7,8 +7,7 @@ extend type Query {
         is_publicly_visible: Boolean @scope(name: "IsPubliclyVisible")
         is_accepting_submissions: Boolean @scope(name: "IsAcceptingSubmissions")
     ): [Publication!]!
-        @paginate(defaultCount: 10)
-        @can(ability: "view", query: true)
+        @paginate(defaultCount: 10, scopes: ["visibleToCurrentUser"])
 }
 
 """

--- a/backend/tests/Api/PublicationTest.php
+++ b/backend/tests/Api/PublicationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Api;
 
 use App\Models\Publication;
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -443,6 +444,85 @@ class PublicationTest extends ApiTestCase
         $json = $response->json('data.publications.data');
 
         $this->assertCount(2, $json);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGuestSeesOnlyPubliclyVisiblePublications()
+    {
+        Publication::factory()->count(2)->create();
+        Publication::factory()->hidden()->count(3)->create();
+
+        $response = $this->graphQL(
+            'query GetPublications {
+                publications {
+                    data { id }
+                }
+            }'
+        );
+
+        $response->assertGraphQLErrorFree();
+        $json = $response->json('data.publications.data');
+        $this->assertCount(2, $json);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMemberSeesPrivatePublicationsTheyBelongTo()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Publication::factory()->count(2)->create();
+        Publication::factory()->hidden()->count(2)->create();
+        $memberPub = Publication::factory()->hidden()->create();
+        $user->publications()->attach($memberPub->id, ['role_id' => Role::EDITOR_ROLE_ID]);
+
+        $response = $this->graphQL(
+            'query GetPublications {
+                publications {
+                    data { id }
+                }
+            }'
+        );
+
+        $response->assertGraphQLErrorFree();
+        $json = $response->json('data.publications.data');
+        $ids = array_column($json, 'id');
+        $this->assertCount(3, $json);
+        $this->assertContains((string)$memberPub->id, $ids);
+    }
+
+    /**
+     * @return void
+     */
+    public function testNonMemberCannotSeePrivatePublications()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Publication::factory()->count(2)->create();
+        $hiddenPubs = Publication::factory()->hidden()->count(3)->create();
+
+        $response = $this->graphQL(
+            'query GetPublications {
+                publications {
+                    data { id }
+                }
+            }'
+        );
+
+        $response->assertGraphQLErrorFree();
+        $json = $response->json('data.publications.data');
+        $ids = array_column($json, 'id');
+        $this->assertCount(2, $json);
+        foreach ($hiddenPubs as $p) {
+            $this->assertNotContains((string)$p->id, $ids);
+        }
     }
 
     protected function executePublicationRoleAssignment(string $role, Publication $publication, User $user)


### PR DESCRIPTION
## Summary
- `GetPublications` returned `This action is unauthorized` whenever the result set contained any private publication the user didn't have a role on. Root cause: `@can(ability: "view", query: true)` iterates every returned `Publication` and throws on the first denied row.
- Replace the `@can` check with a `visibleToCurrentUser` scope applied via `@paginate(scopes: [...])`, filtering at the DB layer instead of throwing.
- Null-guard `PublicationPolicy::view()` so the single-item query handles unauthenticated guests on non-public publications without a null-deref.

## Visibility rules (list query)
- App admin: sees all
- Authenticated user: public publications + any publication they hold a role on
- Guest: public publications only

## Test plan
- [x] `lando backend-test` — 459 passed
- [x] `lando backend-lint` — clean
- [x] `lando client-yarn lint` — clean (1 pre-existing prettier warning, unrelated)
- [x] `lando client-yarn test:unit:ci` — 265 passed
- [x] New tests cover guest / member / non-member visibility