### PR TITLE
chore(lando): add backend-coverage tooling with Xdebug

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,6 +9,7 @@ config:
   composer: []
   webroot: backend/public
   via: nginx
+  xdebug: "coverage"
   config:
     php: backend/php.dev.ini
     vhosts: .lando/default.conf.tpl
@@ -91,6 +92,14 @@ tooling:
     description: Run PHPUnit tests (cwd-independent)
     env:
       DB_CONNECTION: testing
+  backend-coverage:
+    service: appserver
+    cmd: php artisan test --coverage-cobertura=coverage/cobertura.xml --coverage-text
+    dir: /app/backend
+    description: Run PHPUnit with Xdebug coverage (cobertura + text)
+    env:
+      DB_CONNECTION: testing
+      XDEBUG_MODE: coverage
   extras:
     service: client
     cmd: node scripts/lando-extras/extras.js


### PR DESCRIPTION
## Summary
- Add `lando backend-coverage` to run PHPUnit with cobertura + text coverage output
- Enable Xdebug `coverage` mode on the appserver service

## Test plan
- [x] `lando rebuild` picks up the Xdebug coverage config
- [x] `lando backend-coverage` runs tests and emits `coverage/cobertura.xml`