### PR TITLE
ci(fallow): tolerate threshold breaches in health report

### DIFF
--- a/.github/workflows/fallow-report.yml
+++ b/.github/workflows/fallow-report.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -41,7 +43,9 @@ jobs:
           {
             echo "_Updated for [\`${GITHUB_SHA::7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}) by [run #${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})._"
             echo
-            npx fallow health --format markdown
+            # fallow exits nonzero when findings breach thresholds; the report
+            # is a status snapshot, so a breach must not fail the workflow
+            npx fallow health --format markdown || true
           } > "${GITHUB_WORKSPACE}/fallow-report.md"
       - name: Upsert health issue
         env:


### PR DESCRIPTION
## Why

The `Fallow Health Report` workflow failed on master at the "Generate health report" step.

`fallow health` exits nonzero when findings breach thresholds (the high-complexity functions in the codebase). The step runs under `bash -e`, so the nonzero exit failed the whole job — even though the markdown report is written to stdout *before* the exit.

## Fix

- Swallow fallow's exit (`|| true`). The health report is a status snapshot, not a gate; a threshold breach should publish, not fail CI.
- Add `fetch-depth: 0` to the checkout so hotspot git history resolves (was logging "shallow clone detected").