### PR TITLE
ci: dispatch staging deploy to ops repo after master build

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    outputs:
+      # Real tag list emitted by docker/metadata-action (not recomputed).
+      tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Checkout App Release Tag
         uses: actions/checkout@v4
@@ -68,3 +71,36 @@ jobs:
             --url-prefix '~/' \
             /tmp/sourcemap-extract
           npx --yes @sentry/cli@^2 releases finalize "$RELEASE"
+
+  dispatch-deploy:
+    # Trigger a staging deploy in the private ops repo after a master build.
+    needs: publish
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    steps:
+      # Mint a short-lived install token for the ops repo. The GitHub App must be
+      # installed on MESH-Research/pilcrow-deploy with Contents: write.
+      - name: Generate ops token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: MESH-Research
+          repositories: pilcrow-deploy
+      - name: Dispatch staging deploy
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          # The exact tags publish actually pushed (one per line, full image refs).
+          TAGS: ${{ needs.publish.outputs.tags }}
+        run: |
+          # Pull the sha-<digest> tag straight from what was pushed — never recompute.
+          TAG=$(printf '%s\n' "$TAGS" | grep -oiE 'sha-[0-9a-f]{7,40}' | head -1)
+          if [ -z "$TAG" ]; then
+            echo "::error::no sha- tag found in pushed tags:"; printf '%s\n' "$TAGS"
+            exit 1
+          fi
+          gh api repos/MESH-Research/pilcrow-deploy/dispatches \
+            -f event_type=deploy \
+            -f "client_payload[tag]=$TAG" \
+            -f "client_payload[environment]=staging"


### PR DESCRIPTION
## What
After a `master` image build, trigger the staging deploy in the private ops repo (`MESH-Research/pilcrow-deploy`) via `repository_dispatch`.

Adds a `dispatch-deploy` job to `publish-docker.yaml` that:
- mints a short-lived GitHub App install token scoped to `pilcrow-deploy` (reuses existing `APP_ID`/`APP_PRIVATE_KEY` — no new PAT to manage/rotate)
- calls the ops repo `dispatches` API with `event_type=deploy` and `client_payload.tag=sha-<short>`

The ops repo's `deploy-staging.yml` listens for `repository_dispatch: [deploy]`, scp's the staging compose stack to the host, and runs `docker compose up`.

## Prerequisite before this works
The GitHub App must be installed on `MESH-Research/pilcrow-deploy` with **Contents: Read and write** (required for `repository_dispatch`). Ops-repo side already configured: `staging` environment with `SSH_HOST`/`SSH_USER`/`SSH_KEY` secrets and `DEPLOY_PATH` var.

## Why App token over PAT
Short-lived, auto-rotating, repo-scoped; infra already present (release-please uses the same App).