### PR TITLE
ci: fix staging deploy tag — read pushed tag instead of recomputing

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -18,9 +18,6 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-24.04
-    outputs:
-      # Real tag list emitted by docker/metadata-action (not recomputed).
-      tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Checkout App Release Tag
         uses: actions/checkout@v4
@@ -72,15 +69,13 @@ jobs:
             /tmp/sourcemap-extract
           npx --yes @sentry/cli@^2 releases finalize "$RELEASE"
 
-  dispatch-deploy:
-    # Trigger a staging deploy in the private ops repo after a master build.
-    needs: publish
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-24.04
-    steps:
-      # Mint a short-lived install token for the ops repo. The GitHub App must be
-      # installed on MESH-Research/pilcrow-deploy with Contents: write.
+      # --- Trigger a staging deploy in the private ops repo after a master build.
+      # Kept in the publish job (not a separate one) so it reads the build-image
+      # step output directly: job outputs that look secret-ish get masked/skipped
+      # by GitHub ("Skip output 'tags' since it may contain secret"). Steps abort
+      # on a failed build, so the push is guaranteed to have happened first.
       - name: Generate ops token
+        if: github.ref == 'refs/heads/master'
         id: token
         uses: actions/create-github-app-token@v2
         with:
@@ -89,10 +84,11 @@ jobs:
           owner: MESH-Research
           repositories: pilcrow-deploy
       - name: Dispatch staging deploy
+        if: github.ref == 'refs/heads/master'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           # The exact tags publish actually pushed (one per line, full image refs).
-          TAGS: ${{ needs.publish.outputs.tags }}
+          TAGS: ${{ steps.build-image.outputs.tags }}
         run: |
           # Pull the sha-<digest> tag straight from what was pushed — never recompute.
           TAG=$(printf '%s\n' "$TAGS" | grep -oiE 'sha-[0-9a-f]{7,40}' | head -1)


### PR DESCRIPTION
## Problem
PR #2311 passed the deploy tag from `publish` to a separate `dispatch-deploy` job via a **job output** (`needs.publish.outputs.tags`). GitHub refuses to propagate job outputs that look secret-ish — the publish run logged:

> Skip output 'tags' since it may contain secret.

So the output arrives empty and the dispatch would send no/`sha-` tag.

## Fix
Fold the dispatch into the `publish` job as trailing steps, reading `steps.build-image.outputs.tags` **directly** (step outputs in the same job aren't masked-skipped). The sha-`<digest>` tag is grepped from the exact tags `docker/metadata-action` pushed — never recomputed from `GITHUB_SHA`.

- Steps abort on a failed build → push is guaranteed before dispatch (same guarantee `needs:` gave).
- Both new steps gated `if: github.ref == 'refs/heads/master'` so tag/PR builds don't dispatch.
- Fails loud (`::error::`) if no sha- tag is present, instead of deploying a wrong tag.

## Still required before live
GitHub App installed on `MESH-Research/pilcrow-deploy` with Contents: write.