### PR TITLE
chore(renovate): gate PRs behind dashboard, surface high-impact deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
         "config:recommended"
     ],
     /**
+     * Never open PRs automatically. Renovate still scans and lists available
+     * updates on the dependency dashboard issue, but every update requires
+     * manual approval (tick the box on the dashboard) before a PR is created.
+     * Keeps dependency visibility without the open-PR noise.
+     **/
+    "dependencyDashboardApproval": true,
+    /**
      * Recreate PR (close+reopen) when target version bumps so PR age reflects
      * the latest version, not the original branch creation date.
      **/
@@ -131,8 +138,46 @@
         {
             "matchManagers": ["github-actions"],
             "commitMessagePrefix": "ci(gha/deps):"
+        },
+        /**
+         * High-impact core framework deps bypass the dashboard approval gate so
+         * they raise PRs directly (no dashboard-watching). Stability windows from
+         * the rules above still apply. Un-drafted and tagged to stand out.
+         * Adjust this package list as the critical surface changes.
+         **/
+        {
+            "description": "High-impact core deps surface as PRs without dashboard approval",
+            "matchPackageNames": [
+                "vue",
+                "vue-router",
+                "quasar",
+                "@quasar/**",
+                "typescript",
+                "laravel/framework",
+                "laravel/sanctum",
+                "php",
+                "nuwave/lighthouse"
+            ],
+            "dependencyDashboardApproval": false,
+            "draftPR": false,
+            "addLabels": ["high-impact"]
         }
     ],
+    /**
+     * Security advisories bypass the dashboard approval gate above. A dep with a
+     * published vulnerability raises a PR immediately (ignores minimumReleaseAge
+     * and dependencyDashboardApproval) so high-impact fixes surface without
+     * watching the dashboard. Un-drafted and tagged so they stand out.
+     **/
+    "vulnerabilityAlerts": {
+        "draftPR": false,
+        "labels": ["security", "dependencies"]
+    },
+    /**
+     * Broaden advisory coverage beyond GitHub's database using the OSV database
+     * (catches more ecosystems / advisories).
+     **/
+    "osvVulnerabilityAlerts": true,
     "assignees": [
         "wreality"
     ],


### PR DESCRIPTION
## What

Renovate's auto-opened PRs were never merged and became noise. This reconfigures Renovate to stop opening PRs automatically while keeping dependency visibility.

## Changes

- **`dependencyDashboardApproval: true`** (top-level) — no PRs open automatically. Renovate still scans and lists every available update on the dependency dashboard issue; a PR is created only when the box is ticked on the dashboard.
- **`vulnerabilityAlerts` + `osvVulnerabilityAlerts: true`** — security advisories bypass the approval gate and raise PRs immediately (ignoring stability windows), labeled `security`. Broadened advisory coverage via the OSV database.
- **High-impact core dep carve-out** — `vue`, `vue-router`, `quasar`, `@quasar/*`, `typescript`, `laravel/framework`, `laravel/sanctum`, `php`, `nuwave/lighthouse` bypass the approval gate and raise PRs (labeled `high-impact`). Stability windows still apply.

Net effect: the long tail of routine deps is dashboard-only (quiet), while security and core-framework updates actively surface as PRs — no dashboard-watching required for the stuff that matters.

## Notes

- GitHub source requires repo **Dependabot alerts** enabled for `vulnerabilityAlerts` to trigger.
- Package names verified against `backend/composer.json` and `client/package.json`. Tune the `matchPackageNames` list as the critical surface changes.