### PR TITLE
fix(client): keep dev server up on startup lint error (#2303)

### DIFF
--- a/client/quasar.config.ts
+++ b/client/quasar.config.ts
@@ -151,6 +151,12 @@ export default defineConfig(function (/* ctx */) {
           {
             lintOnStart: true,
             fix: false,
+            // Emit lint errors as warnings during local dev so a committed
+            // lint error surfaces in the overlay/console without aborting
+            // Vite startup (PluginContext.error() throws and kills the dev
+            // server -> 502). Lint is still a hard gate in CI via `yarn lint`,
+            // which runs the ESLint CLI independently of this plugin. See #2303.
+            emitErrorAsWarning: true,
           }
         ],
         [


### PR DESCRIPTION
## Problem

A single ESLint **error** crashes the client dev server: `vite-plugin-eslint2` with `lintOnStart: true` lints the whole tree in the rollup `buildStart` hook and calls `PluginContext.error()` on any error, which throws and aborts Vite startup (exit 1). The container exits and nginx returns **502** — an opaque failure that looks like an infra/proxy problem, not a lint problem.

Triggered in practice once #2302 added the error-level `@intlify/vue-i18n/no-raw-text` rule, which matched committed code.

Fixes #2303.

## Fix

Set `emitErrorAsWarning: true` on the eslint plugin (issue's Option 2):

- Plugin emits boot/per-file lint errors via `context.warn()` instead of `context.error()` — error still surfaces in the overlay/console, but no longer throws and kills the server.
- `lintOnStart` whole-tree feedback is preserved.
- **Lint stays a hard CI gate** via `yarn lint` (ESLint CLI), which runs independently of this Vite plugin — this change affects local dev only.

## Verification

Drove the real plugin's `buildStart` against a `src/` `.vue` file with a genuine `no-raw-text` error, using the project's ESLint config:

| Config | `buildStart` | Result |
|--------|-------------|--------|
| Without fix (default) | `context.error()` throws | dev server dies → 502 |
| With fix (`emitErrorAsWarning: true`) | `context.warn()`, resolves | dev server boots, error shown as warning |

Confirmed the ESLint CLI still exits non-zero on the same error (CI gate intact).