### PR TITLE
ci: pass deployed commit sha to staging deploy

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -99,4 +99,5 @@ jobs:
           gh api repos/MESH-Research/pilcrow-deploy/dispatches \
             -f event_type=deploy \
             -f "client_payload[tag]=$TAG" \
+            -f "client_payload[sha]=$GITHUB_SHA" \
             -f "client_payload[environment]=staging"


### PR DESCRIPTION
Adds `client_payload[sha]=$GITHUB_SHA` to the staging deploy dispatch.

The ops repo (`pilcrow-deploy`) now uses this to create a GitHub **Deployment on the Pilcrow repo** keyed to the actual deployed commit, then reports real success/failure after `docker compose up`. The Pilcrow **Environments → staging** page will show the deployed sha + a link to staging, instead of the static ops-repo commit.

Requires (ops side, already pushed): App `pilcrow-github-actions` granted **deployments: write** on Pilcrow (org approval) + `APP_PRIVATE_KEY` secret in the ops repo. Until then the deployment record is skipped gracefully and the deploy still runs.