### PR TITLE
fix: Dark mode for record of review

### DIFF
--- a/client/codegen.ts
+++ b/client/codegen.ts
@@ -14,25 +14,25 @@ const config: CodegenConfig = {
     "src/pages/**/*.vue",
     "src/layouts/**/*.vue",
     "src/components/**/*.vue",
-    "src/routes/**/*.vue",
+    "src/routes/**/*.vue"
   ],
   generates: {
     "src/graphql/generated/": {
       preset: "client",
       presetConfig: {
-        fragmentMasking: false,
+        fragmentMasking: false
       },
       config: {
         namingConvention: "keep",
-        maybeValue: "T | null | undefined",
-      },
+        maybeValue: "T | null | undefined"
+      }
     },
     "src/graphql/generated/possibleTypes.ts": {
       plugins: ["fragment-matcher"],
       config: {
         apolloClientVersion: 3,
-        useExplicitTyping: true,
-      },
+        useExplicitTyping: true
+      }
     },
     // Always emit a normalized schema.graphql via schema-ast so the
     // committed snapshot uses graphql-js's printer regardless of source
@@ -42,10 +42,10 @@ const config: CodegenConfig = {
     "src/graphql/schema.graphql": {
       plugins: ["schema-ast"],
       config: {
-        sort: true,
-      },
-    },
-  },
+        sort: true
+      }
+    }
+  }
 }
 
 export default config

--- a/client/quasar.config.ts
+++ b/client/quasar.config.ts
@@ -57,7 +57,7 @@ export default defineConfig(function (/* ctx */) {
       sourcemap: "hidden",
       typescript: {
         strict: false,
-        vueShim: true,
+        vueShim: true
       },
 
       target: {
@@ -94,20 +94,30 @@ export default defineConfig(function (/* ctx */) {
             let debounceTimer: ReturnType<typeof setTimeout> | null = null
             server.watcher.add(backendGraphqlDir)
             server.watcher.on("change", (filePath) => {
-              if (!filePath.startsWith(backendGraphqlDir) || !filePath.endsWith(".graphql")) return
+              if (
+                !filePath.startsWith(backendGraphqlDir) ||
+                !filePath.endsWith(".graphql")
+              )
+                return
               if (debounceTimer) clearTimeout(debounceTimer)
               debounceTimer = setTimeout(async () => {
                 try {
-                  const { generate, loadContext } = await import("@graphql-codegen/cli")
+                  const { generate, loadContext } =
+                    await import("@graphql-codegen/cli")
                   const ctx = await loadContext()
                   await generate({ ...ctx.getConfig(), watch: false })
-                  console.log("[watch-backend-schema] Types regenerated after schema change")
+                  console.log(
+                    "[watch-backend-schema] Types regenerated after schema change"
+                  )
                 } catch (e) {
-                  console.warn("[watch-backend-schema] Codegen failed:", (e as Error).message)
+                  console.warn(
+                    "[watch-backend-schema] Codegen failed:",
+                    (e as Error).message
+                  )
                 }
               }, 500)
             })
-          },
+          }
         })
       },
       vueRouterMode: "history", // available values: 'hash', 'history'
@@ -142,7 +152,7 @@ export default defineConfig(function (/* ctx */) {
         [
           checker,
           {
-            vueTsc: true,
+            vueTsc: true
           },
           { server: false }
         ],
@@ -156,7 +166,7 @@ export default defineConfig(function (/* ctx */) {
             // Vite startup (PluginContext.error() throws and kills the dev
             // server -> 502). Lint is still a hard gate in CI via `yarn lint`,
             // which runs the ESLint CLI independently of this plugin. See #2303.
-            emitErrorAsWarning: true,
+            emitErrorAsWarning: true
           }
         ],
         [
@@ -168,10 +178,10 @@ export default defineConfig(function (/* ctx */) {
             matchOnDocuments: true,
             matchOnSchemas: false,
             configOverrideOnBuild: {
-              schema: "src/graphql/schema.graphql",
-            },
-          },
-        ],
+              schema: "src/graphql/schema.graphql"
+            }
+          }
+        ]
       ],
       useFilenameHashes: false
     },
@@ -236,6 +246,6 @@ export default defineConfig(function (/* ctx */) {
       middlewares: [
         "render" // keep this as last one
       ]
-    },
+    }
   }
 })

--- a/client/src/components/labs/LabsFeaturePanel.vue
+++ b/client/src/components/labs/LabsFeaturePanel.vue
@@ -17,8 +17,7 @@
 
       <q-btn
         no-caps
-        :outline="optedIn"
-        :color="optedIn ? 'grey-8' : 'primary'"
+        :color="optedIn ? 'negative' : 'primary'"
         :label="optedIn ? $t('labs.deactivate') : $t('labs.activate')"
         :loading="saving"
         :data-cy="`labs_feature_${featureKey}`"

--- a/client/src/components/molecules/FieldDisplay.vue
+++ b/client/src/components/molecules/FieldDisplay.vue
@@ -3,7 +3,8 @@
     <q-icon v-if="icon" :name="icon" size="xs" class="field-display__icon" />
     <div class="col">
       <div
-        class="field-display__label text-caption text-weight-medium text-grey-7"
+        :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
+        class="field-display__label text-caption text-weight-medium"
       >
         {{ label }}
       </div>
@@ -20,6 +21,7 @@ interface Props {
   value?: string
   icon?: string
   valueClass?: string
+  darkModeStatus?: boolean
 }
 
 withDefaults(defineProps<Props>(), {

--- a/client/src/components/ror/RecordOfReview.vue
+++ b/client/src/components/ror/RecordOfReview.vue
@@ -10,7 +10,7 @@
     />
     <div ref="recordContainer" class="ror__document">
       <header class="ror__header">
-        <p class="ror__eyebrow">
+        <p class="ror__eyebrow text-primary">
           {{ $t("record_of_review.eyebrow") }}
         </p>
         <h1 class="text-h2 q-mt-none ror__title" data-cy="page_heading">
@@ -139,7 +139,7 @@
             scope="global"
           >
             <template #host>
-              <a :href="siteUrl" class="ror__footer-link">{{ issuingHost }}</a>
+              <a :href="siteUrl" class="ror__footer-link text-primary">{{ issuingHost }}</a>
             </template>
             <template #publication>
               <router-link
@@ -147,7 +147,7 @@
                   name: 'publication:home',
                   params: { id: submission.publication.id }
                 }"
-                class="ror__footer-link"
+                class="ror__footer-link text-primary"
               >
                 {{ submission.publication.name }}
               </router-link>
@@ -311,9 +311,6 @@ defineExpose({
   position: relative
 
 .ror__document
-  background: #fbfbf3
-  color: $dark
-  color-scheme: light
   border: 1px solid $light-grey
   border-radius: 8px
   position: relative
@@ -333,9 +330,8 @@ defineExpose({
   font-size: 0.75rem
   font-weight: 600
   letter-spacing: 0.25em
-  text-transform: uppercase
-  color: $primary
   margin: 0 0 0.5rem
+  text-transform: uppercase
 
 .ror__title
   font-family: 'Georgia', 'Times New Roman', serif
@@ -344,7 +340,6 @@ defineExpose({
 
 .ror__subtitle
   font-style: italic
-  color: $dark-6
   margin: 0
 
 .ror__rule
@@ -365,7 +360,6 @@ defineExpose({
   font-weight: 600
   letter-spacing: 0.05em
   text-transform: uppercase
-  color: $secondary
   border-bottom: 1px solid $light-grey
   padding-bottom: 0.25rem
   margin-bottom: 0.75rem
@@ -379,7 +373,6 @@ defineExpose({
 
   dt
     font-weight: 600
-    color: $dark-6
     text-transform: uppercase
     font-size: 0.75rem
     letter-spacing: 0.08em
@@ -387,7 +380,6 @@ defineExpose({
 
   dd
     margin: 0
-    color: $dark
 
 .ror__footer
   padding: 1.5rem 2rem
@@ -424,16 +416,13 @@ defineExpose({
 
 .ror__footer-line
   font-style: italic
-  color: $dark-6
   margin: 0 0 0.25rem
 
 .ror__footer-link
-  color: $primary
   text-decoration: underline
   font-style: normal
 
 .ror__footer-detail
   font-size: 0.8rem
-  color: $dark-6
   margin: 0
 </style>

--- a/client/src/components/ror/RecordOfReview.vue
+++ b/client/src/components/ror/RecordOfReview.vue
@@ -139,7 +139,9 @@
             scope="global"
           >
             <template #host>
-              <a :href="siteUrl" class="ror__footer-link text-primary">{{ issuingHost }}</a>
+              <a :href="siteUrl" class="ror__footer-link text-primary">{{
+                issuingHost
+              }}</a>
             </template>
             <template #publication>
               <router-link

--- a/client/src/components/ror/RecordOfReviewTable.vitest.spec.ts
+++ b/client/src/components/ror/RecordOfReviewTable.vitest.spec.ts
@@ -190,8 +190,7 @@ describe("RecordOfReviewTable selection reset", () => {
 
   it("does not emit a redundant reset when nothing is selected", async () => {
     const wrapper = await mountTable()
-    const updates = () =>
-      wrapper.emitted("update:selected")?.length ?? 0
+    const updates = () => wrapper.emitted("update:selected")?.length ?? 0
     const before = updates()
     panel(wrapper).vm.$emit("update:publicationFilter", "12")
     await flushPromises()

--- a/client/src/components/ror/RecordOfReviewTable.vue
+++ b/client/src/components/ror/RecordOfReviewTable.vue
@@ -88,7 +88,11 @@
       <q-td :props="p">{{ p.row.submission.id }}</q-td>
     </template>
     <template #body-cell-title="p">
-      <WithAsideCell :scope="p" style="white-space: normal">
+      <WithAsideCell
+        :scope="p"
+        :dark-mode-status="darkModeStatus"
+        style="white-space: normal"
+      >
         <template #value>
           <router-link
             data-cy="submission_link_desktop"
@@ -116,7 +120,11 @@
             <AvatarImage :user="submitter" size="32px" rounded />
             <div class="column">
               <div v-if="submitter.name">{{ submitter.name }}</div>
-              <div v-if="submitter.username" class="text-caption text-grey-8">
+              <div
+                v-if="submitter.username"
+                :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
+                class="text-caption"
+              >
                 {{ submitter.username }}
               </div>
             </div>
@@ -180,7 +188,9 @@ import AvatarImage from "src/components/atoms/AvatarImage.vue"
 import RecordOfReviewCard from "src/components/ror/RecordOfReviewCard.vue"
 import SubmissionsFilterPanel from "src/pages/Admin/components/SubmissionsFilterPanel.vue"
 import { defaultOptions as defaultRoleOptions } from "src/pages/Admin/components/SubmissionsFilterPanelRoles.vue"
+import { useDarkMode } from "src/use/guiElements"
 
+const { darkModeStatus } = useDarkMode()
 const $q = useQuasar()
 const { t } = useI18n()
 
@@ -265,7 +275,10 @@ const cols: QueryTableColumn[] = [
     field: (row) => (row.submission as Submission).updated_at,
     sortable: false,
     align: "left",
-    component: DateTimeCell
+    component: DateTimeCell,
+    props: () => ({
+      darkModeStatus: darkModeStatus.value
+    })
   }
 ]
 

--- a/client/src/components/ror/RecordOfReviewUser.vue
+++ b/client/src/components/ror/RecordOfReviewUser.vue
@@ -4,12 +4,17 @@
       <h3 class="text-h4 text-bold rorr-user__name">
         {{ user.display_label }}
       </h3>
-      <p class="rorr-user__role">{{ role }}</p>
+      <p
+        :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
+        class="rorr-user__role"
+      >
+        {{ role }}
+      </p>
       <dl
         v-if="user.profile_metadata?.academic_profiles?.orcid_id"
         class="rorr-user__dl"
       >
-        <dt>
+        <dt :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'">
           {{
             $t(
               "account.profile.fields.profile_metadata.academic_profiles.orcid_id.label"
@@ -40,6 +45,8 @@ graphql(`
 
 <script setup lang="ts">
 import type { recordOfReviewUserFragment } from "src/graphql/generated/graphql"
+import { useDarkMode } from "src/use/guiElements"
+const { darkModeStatus } = useDarkMode()
 interface Props {
   user: recordOfReviewUserFragment
   role: string
@@ -53,7 +60,6 @@ defineProps<Props>()
 .rorr-user
   width: 220px
   background: transparent
-  color: $dark
   border: 1px solid $light-grey
 
 .rorr-user__inner
@@ -72,7 +78,6 @@ defineProps<Props>()
   font-size: 0.7rem
   letter-spacing: 0.1em
   text-transform: uppercase
-  color: $primary
   font-weight: 600
   margin: 0 0 0.75rem
 
@@ -84,7 +89,6 @@ defineProps<Props>()
     font-size: 0.65rem
     text-transform: uppercase
     letter-spacing: 0.08em
-    color: $dark-6
     margin-top: 0.25rem
 
   dd

--- a/client/src/components/tables/QueryTable.vue
+++ b/client/src/components/tables/QueryTable.vue
@@ -142,6 +142,7 @@
         v-if="column.component"
         :scope="scope"
         :dense="effectiveDense"
+        v-bind="column.props?.(scope) ?? {}"
       />
     </template>
   </q-table>
@@ -428,7 +429,12 @@ const compColumns = computed(() => {
     return []
   }
   return props.columns.filter(
-    (c): c is QueryTableColumn & { component: Component } => !!c.component
+    (
+      c
+    ): c is QueryTableColumn & {
+      component: Component
+      props?: (scope: QTableBodyCellScope) => Record<string, unknown>
+    } => !!c.component
   )
 })
 

--- a/client/src/components/tables/QueryTable.vue
+++ b/client/src/components/tables/QueryTable.vue
@@ -163,6 +163,7 @@ type QTableColumn = NonNullable<QTableProps["columns"]>[number]
 // callers union them into the columns array as needed.
 export interface QueryTableColumn extends Omit<QTableColumn, "label"> {
   component?: Component
+  props?: object
 }
 
 export interface QTableBodyCellScope<TCol = QTableColumn> {

--- a/client/src/components/tables/common/DateTimeCell.vue
+++ b/client/src/components/tables/common/DateTimeCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <WithAsideCell :scope="scope">
+  <WithAsideCell :scope="scope" :dark-mode-status="darkModeStatus">
     <template #value>
       {{ absolute }}
     </template>
@@ -18,6 +18,7 @@ import type { QTableBodyCellScope } from "../QueryTable.vue"
 
 interface Props {
   scope: QTableBodyCellScope
+  darkModeStatus?: boolean
 }
 
 const props = defineProps<Props>()

--- a/client/src/components/tables/common/WithAsideCell.vue
+++ b/client/src/components/tables/common/WithAsideCell.vue
@@ -6,7 +6,11 @@
           {{ scope.value }}
         </slot>
       </div>
-      <div class="text-caption text-grey-8">
+      <div
+        :dark-mode-status="darkModeStatus"
+        :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
+        class="text-caption"
+      >
         <slot name="aside" v-bind="scope">
           {{ asideLabel }}: {{ asideValue }}
         </slot>
@@ -29,9 +33,12 @@ import { computed } from "vue"
 
 interface Props {
   scope: QTableBodyCellScope<WithAsideColumn>
+  darkModeStatus?: boolean
 }
 
 const props = defineProps<Props>()
+
+const darkModeStatus = computed(() => props.darkModeStatus)
 
 const asideValue = computed(() => {
   const aside = props.scope.col.aside

--- a/client/src/routes/account/labs/record-of-review.vitest.spec.ts
+++ b/client/src/routes/account/labs/record-of-review.vitest.spec.ts
@@ -68,9 +68,7 @@ describe("Record of Review labs page", () => {
   it("links to the Fider feedback board in a new tab", () => {
     const link = factory().find("[data-cy=ror_feedback_link]")
     expect(link.exists()).toBe(true)
-    expect(link.attributes("href")).toBe(
-      "https://feedback.pilcrow.dev/"
-    )
+    expect(link.attributes("href")).toBe("https://feedback.pilcrow.dev/")
     expect(link.attributes("target")).toBe("_blank")
     expect(link.attributes("rel")).toContain("noopener")
   })

--- a/client/src/routes/account/labs/record-of-review.vue
+++ b/client/src/routes/account/labs/record-of-review.vue
@@ -18,7 +18,6 @@
         rel="noopener noreferrer"
         no-caps
         outline
-        color="primary"
         icon="forum"
         icon-right="open_in_new"
         :label="$t('labs.record_of_review.feedback')"

--- a/client/src/routes/admin/user/[id].vitest.spec.ts
+++ b/client/src/routes/admin/user/[id].vitest.spec.ts
@@ -13,8 +13,10 @@ vi.mock("vue-router", () => ({
 }))
 
 const mockNewStatus = vi.fn()
+const mockDarkMode = vi.fn()
 vi.mock("src/use/guiElements", () => ({
-  useFeedbackMessages: () => ({ newStatusMessage: mockNewStatus })
+  useFeedbackMessages: () => ({ newStatusMessage: mockNewStatus }),
+  useDarkMode: () => ({ darkModeStatus: mockDarkMode })
 }))
 
 installQuasarPlugin()

--- a/client/src/routes/admin/user/[id].vue
+++ b/client/src/routes/admin/user/[id].vue
@@ -10,7 +10,10 @@
         </q-card-section>
         <q-card-section class="col">
           <div class="text-h5">{{ user.name || user.username }}</div>
-          <div class="text-subtitle1 text-grey-7 q-mb-sm">
+          <div
+            :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
+            class="text-subtitle1 q-mb-sm"
+          >
             @{{ user.username }}
           </div>
           <div class="row q-col-gutter-x-lg q-col-gutter-y-sm">
@@ -19,11 +22,13 @@
               icon="email"
               :label="$t('admin.users.details.email')"
               :value="user.email"
+              :dark-mode-status="darkModeStatus"
             />
             <FieldDisplay
               class="col-sm-6 col-xs-12"
               icon="verified"
               :label="$t('admin.users.details.verified_at')"
+              :dark-mode-status="darkModeStatus"
             >
               <span v-if="user.email_verified_at">
                 {{ formatDateTime(user.email_verified_at) }}
@@ -36,6 +41,7 @@
               class="col-sm-6 col-xs-12"
               icon="key"
               :label="$t('admin.users.details.role')"
+              :dark-mode-status="darkModeStatus"
             >
               <span v-if="isAdmin">
                 {{ $t("admin.users.details.isAdmin") }}
@@ -47,11 +53,13 @@
               icon="calendar_today"
               :label="$t('admin.users.details.created_at')"
               :value="formatDateTime(user.created_at)"
+              :dark-mode-status="darkModeStatus"
             />
             <FieldDisplay
               class="col-sm-6 col-xs-12"
               icon="science"
               :label="$t('admin.users.details.beta')"
+              :dark-mode-status="darkModeStatus"
             >
               <q-toggle
                 :model-value="user.beta"
@@ -70,6 +78,7 @@
               class="col-xs-12"
               icon="o_science"
               :label="$t('admin.users.details.feature_opt_ins')"
+              :dark-mode-status="darkModeStatus"
             >
               <div
                 v-if="optedInFeatures.length"
@@ -87,7 +96,7 @@
               </div>
               <span
                 v-else
-                class="text-grey-5"
+                :class="darkModeStatus ? 'text-grey-5' : 'text-grey-8'"
                 data-cy="user_no_feature_opt_ins"
               >
                 {{ $t("admin.users.details.no_feature_opt_ins") }}
@@ -162,7 +171,7 @@ import { useRoute } from "vue-router"
 import { DateTime } from "luxon"
 import { useI18n } from "vue-i18n"
 import { setCrumbLabel } from "src/use/breadcrumbs"
-import { useFeedbackMessages } from "src/use/guiElements"
+import { useFeedbackMessages, useDarkMode } from "src/use/guiElements"
 
 definePage({
   // Named so setCrumbLabel below can target it by name. The user
@@ -181,6 +190,7 @@ definePage({
   }
 })
 
+const { darkModeStatus } = useDarkMode()
 const route = useRoute("admin:user:id")
 const id = computed(() => route.params.id as string)
 

--- a/client/src/use/guiElements.ts
+++ b/client/src/use/guiElements.ts
@@ -6,11 +6,11 @@ import type { Submission } from "src/graphql/generated/graphql"
 
 export function useDarkMode() {
   const $q = useQuasar()
-  const darkModeStatus = ref($q.dark.isActive)
+  const darkModeStatus = ref($q?.dark.isActive)
   watch(
-    () => $q.dark.isActive,
+    () => $q?.dark.isActive,
     () => {
-      darkModeStatus.value = $q.dark.isActive
+      darkModeStatus.value = $q?.dark.isActive
     }
   )
   function toggleDarkMode() {

--- a/client/test/cypress/support/index.d.ts
+++ b/client/test/cypress/support/index.d.ts
@@ -4,43 +4,42 @@ declare namespace Cypress {
      * Custom command to select DOM element by data-cy attribute.
      * @example cy.dataCy('greeting')
      */
-    dataCy<E extends Node = HTMLElement>(value: string): Chainable<JQuery<E>>;
+    dataCy<E extends Node = HTMLElement>(value: string): Chainable<JQuery<E>>
 
     /**
      * Custom command to test being on a given route.
      * @example cy.testRoute('home')
      */
-    testRoute(value: string): void;
+    testRoute(value: string): void
 
     /**
      * Persist current local storage data.
      * @example cy.saveLocalStorage()
      */
-    saveLocalStorage(): void;
+    saveLocalStorage(): void
 
     /**
      * Restore saved data to local storage.
      * @example cy.restoreLocalStorage()
      */
-    restoreLocalStorage(): void;
+    restoreLocalStorage(): void
 
     /**
      * Login a user without supplying credentials.
      * @example cy.login({email: "user@example.com"})
      */
-    login(user: UserInput): UserObject;
+    login(user: UserInput): UserObject
 
     /**
      * Logout the user.
      */
-    logout(): UserObject;
+    logout(): UserObject
 
     /** Requests and returns a new xsrfToken
-     * 
+     *
      * @example cy.xsrfToken().then((token) => {...})
      */
-    xsrfToken(): string;
-
+    xsrfToken(): string
   }
 
   interface UserInput {
@@ -52,6 +51,5 @@ declare namespace Cypress {
     name: string
     username: string
     id: number
-
   }
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,4 @@
 {
   "extends": "./.quasar/tsconfig.json",
-  "exclude": [
-    "test/cypress"
-  ]
+  "exclude": ["test/cypress"]
 }


### PR DESCRIPTION
This pull request: 

* Makes the previewed Record of Review as it appears in Pilcrow respect users' light/dark mode preferences
* Fixes insufficient color contrast on text related to this feature
* Fixes uses of the `$primary` color applied on text, which has been adjusted in the past in `.text-primary` for sufficient color contrast on primary-colored text presented in dark mode