### PR TITLE
feat(config): deployment-supplied filesystem disks seam

### DIFF
--- a/backend/config/filesystems.php
+++ b/backend/config/filesystems.php
@@ -1,5 +1,19 @@
 <?php
 
+/*
+| Optional deployment-supplied disks. The application defines the seam; the
+| deployment owns the content. Point FILESYSTEM_DISKS_CONFIG at a PHP file that
+| returns an array of disk definitions and they are merged into the disks below
+| (deployment keys win on conflict). This keeps host-/environment-specific
+| storage choices — an off-host backup bucket, an object store, etc. — out of
+| the application's own config and lets each deployment add disks without a code
+| change here. Inert unless the env var points at a readable file.
+*/
+$deploymentDisks = [];
+if (($deploymentDisksConfig = env('FILESYSTEM_DISKS_CONFIG')) && is_file($deploymentDisksConfig)) {
+    $deploymentDisks = require $deploymentDisksConfig;
+}
+
 return [
 
     /*
@@ -28,7 +42,7 @@ return [
     |
     */
 
-    'disks' => [
+    'disks' => array_merge([
 
         'local' => [
             'driver' => 'local',
@@ -52,7 +66,7 @@ return [
             'endpoint' => env('AWS_ENDPOINT'),
         ],
 
-    ],
+    ], $deploymentDisks),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a small, generic extension point to \`config/filesystems.php\`: an optional **deployment-supplied** set of disk definitions, merged in via a new \`FILESYSTEM_DISKS_CONFIG\` env var (a path to a PHP file returning a disks array).

```php
$deploymentDisks = [];
if (($p = env('FILESYSTEM_DISKS_CONFIG')) && is_file($p)) {
    $deploymentDisks = require $p;
}
// ...
'disks' => array_merge([ /* local, public, s3 */ ], $deploymentDisks),
```

## Why

A deployment needs to add storage disks the app shouldn't have to know about — e.g. an off-host backup bucket on whatever object store that environment uses. Today the only ways are:

- **Edit the app** to hard-code each environment's disk (couples app config to one deployment's choices), or
- **Bind-mount a whole replacement \`filesystems.php\`** (silently shadows the app's own disks — drift risk when the app later adds one).

This seam splits the concern cleanly: the **app owns the extension point** (written once, never needs to change again), the **deployment owns the content**. It stays agnostic to *how* any given instance is deployed.

## Behavior

- **Inert by default.** Env var unset or file missing → empty merge → unchanged behavior.
- **Deployment keys win on conflict** (merged second), so a deployment may also override a built-in disk.
- Config isn't cached in our images, so the \`require\` runs at runtime; if \`config:cache\` is ever enabled the file just needs to exist at cache time.

## Trust

\`require\` executes a PHP file the deployment controls — the same trust boundary as \`.env\`/the compose stack the operator already owns. No new exposure.

## First consumer

Production backups → DigitalOcean Spaces: the deploy repo supplies a \`spaces\` disk reading dedicated \`DO_SPACES_*\` env (kept separate from SES's \`AWS_*\`, which the stock \`s3\` disk would otherwise collide with) and sets \`BACKUP_DISKS=spaces\`.

## Note

Ran \`php -l\` (clean); please confirm \`lando backend-lint\` (Pint) in an active worktree — vendor isn't installed in the throwaway worktree this was authored in.