### PR TITLE
fix(submission): enforce single review coordinator per submission (#2324)

### DIFF
--- a/backend/app/GraphQL/Mutations/InviteSubmissionUser.php
+++ b/backend/app/GraphQL/Mutations/InviteSubmissionUser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Auth\Roles\ScopedRole;
+use App\Exceptions\ClientException;
 use App\Models\Submission;
 use App\Models\SubmissionInvitation;
 
@@ -44,6 +45,7 @@ final class InviteSubmissionUser
     public function inviteReviewCoordinator($_, array $args)
     {
         $submission = Submission::where('id', $args['submission_id'])->firstOrFail();
+        $this->guardAgainstExistingCoordinator($submission);
         $invite = SubmissionInvitation::create([
             'submission_id' => $submission->id,
             'role' => ScopedRole::ReviewCoordinator->toSlug(),
@@ -53,5 +55,25 @@ final class InviteSubmissionUser
         ]);
 
         return $invite->inviteReviewCoordinator();
+    }
+
+    /**
+     * A submission may have at most one review coordinator. Reject the invite if
+     * one already exists, rather than silently creating an invalid
+     * multi-coordinator state (the pivot has no DB constraint enforcing this).
+     *
+     * @param \App\Models\Submission $submission
+     * @return void
+     * @throws \App\Exceptions\ClientException
+     */
+    private function guardAgainstExistingCoordinator(Submission $submission): void
+    {
+        if ($submission->reviewCoordinators()->exists()) {
+            throw new ClientException(
+                'This submission already has a review coordinator.',
+                'submissionInvitation',
+                'SUBMISSION_ALREADY_HAS_COORDINATOR'
+            );
+        }
     }
 }

--- a/backend/tests/Api/SubmissionInvitationTest.php
+++ b/backend/tests/Api/SubmissionInvitationTest.php
@@ -199,6 +199,93 @@ class SubmissionInvitationTest extends ApiTestCase
     }
 
     /**
+     * A submission may have at most one review coordinator. Inviting a second
+     * (different) coordinator through the API is rejected with a typed error and
+     * does not create an invitation, leaving the original coordinator intact.
+     *
+     * @return void
+     */
+    public function testCannotInviteASecondReviewCoordinator()
+    {
+        $this->beAppAdmin();
+        $submission = Submission::factory()->create();
+
+        // First coordinator is staged + attached.
+        SubmissionInvitation::create([
+            'submission_id' => $submission->id,
+            'role' => ScopedRole::ReviewCoordinator->toSlug(),
+            'email' => 'first.coordinator@gmail.com',
+        ])->inviteReviewCoordinator();
+
+        $response = $this->graphQL(
+            'mutation InviteReviewCoordinator ($submission_id: ID! $email: String! $message: String){
+                inviteReviewCoordinator(input: {
+                  submission_id: $submission_id
+                  email: $email
+                  message: $message
+                }) {
+                  id
+                }
+              }
+            ',
+            [
+                'submission_id' => $submission->id,
+                'email' => 'second.coordinator@gmail.com',
+                'message' => '',
+            ]
+        );
+
+        $response->assertJsonPath('errors.0.extensions.code', 'SUBMISSION_ALREADY_HAS_COORDINATOR');
+        // The rejected invite is pre-empted before any row is written.
+        $this->assertDatabaseMissing('submission_invitations', [
+            'email' => 'second.coordinator@gmail.com',
+        ]);
+        $this->assertCount(1, $submission->fresh()->reviewCoordinators);
+    }
+
+    /**
+     * The coordinator-uniqueness guard must not over-block: a reviewer can still
+     * be invited to a submission that already has a (different) coordinator.
+     *
+     * @return void
+     */
+    public function testReviewerCanStillBeInvitedWhenCoordinatorExists()
+    {
+        $this->beAppAdmin();
+        $submission = Submission::factory()->create();
+
+        SubmissionInvitation::create([
+            'submission_id' => $submission->id,
+            'role' => ScopedRole::ReviewCoordinator->toSlug(),
+            'email' => 'the.coordinator@gmail.com',
+        ])->inviteReviewCoordinator();
+
+        $response = $this->graphQL(
+            'mutation InviteReviewer ($submission_id: ID! $email: String! $message: String){
+                inviteReviewer(input: {
+                  submission_id: $submission_id
+                  email: $email
+                  message: $message
+                }) {
+                  id
+                  reviewers { email staged }
+                }
+              }
+            ',
+            [
+                'submission_id' => $submission->id,
+                'email' => 'a.reviewer@gmail.com',
+                'message' => '',
+            ]
+        );
+
+        $response->assertJsonPath('data.inviteReviewer.reviewers', [
+            ['email' => 'a.reviewer@gmail.com', 'staged' => true],
+        ]);
+        $this->assertNull($response->json('errors'));
+    }
+
+    /**
      * @return array
      */
     public static function invalidEmailsProvider(): array


### PR DESCRIPTION
Closes #2324.

## Problem

The GraphQL API let a submission acquire more than one `review_coordinator`. A direct `inviteReviewCoordinator` call on a submission that already has a coordinator succeeded, leaving an invalid multi-coordinator state. The UI gates this (you must remove the existing coordinator first), but the API had no equivalent guard.

The pivot's only uniqueness key — `submission_user_unique (user_id, submission_id)` — blocks the *same* user from holding two roles, but not *two different users* both being `review_coordinator` on one submission. That's the gap.

## Fix

Application-level enforcement in `InviteSubmissionUser::inviteReviewCoordinator`: before creating the invitation, reject if the submission already has a coordinator with a typed `ClientException`:

- `code: SUBMISSION_ALREADY_HAS_COORDINATOR`, `category: submissionInvitation`
- surfaces as `errors.0.extensions.code` — same domain-error pattern as `VerifyEmail`. No 500 / raw SQL error.

Notes:

- The guard runs **before** `SubmissionInvitation::create`, so a rejected invite leaves no orphan invitation row.
- `reviewCoordinators()->exists()` is true as soon as the pivot row is staged (attach happens at invite time, not accept time), so a staged-but-unaccepted coordinator correctly counts as "already has a coordinator."
- The separate `reinviteReviewCoordinator` path is untouched — re-inviting the existing coordinator still works.

### On the "multiple roles for one user" case

The issue and follow-up discussion also raised preventing a single user from holding multiple roles on one submission. That path is **already** covered: the existing `SubmissionInvitationValidator` applies `Rule::unique('users','email')`, so inviting any email that already maps to a user is rejected cleanly with a `NOT_UNIQUE` validation error before any attach — there is no raw DB violation to fix. No change needed there.

### Defense-in-depth (not included)

The issue suggested an optional DB-level guard (a STORED generated column `coord_guard` + unique key, since MySQL has no partial unique index). Left out to keep this change focused; the app-level guard satisfies the acceptance criteria. Can be added as a follow-up if hard DB enforcement is wanted.

## Tests

`backend/tests/Api/SubmissionInvitationTest.php`:

- `testCannotInviteASecondReviewCoordinator` — second coordinator (different user) rejected with the typed code; no invitation row written; original coordinator intact.
- `testReviewerCanStillBeInvitedWhenCoordinatorExists` — guard does not over-block reviewers when a coordinator exists.

All Api + Feature submission-invitation tests pass; `backend-lint` clean.