### PR TITLE
ci(gha/deps): bump GitHub Actions to flagged major versions

### DIFF
--- a/.github/workflows/CI-helm.yaml
+++ b/.github/workflows/CI-helm.yaml
@@ -14,7 +14,7 @@ jobs:
   helm-tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: d3adb5/helm-unittest-action@v2
       - run: |
           helm dependency update helm

--- a/.github/workflows/approve-pr.yml
+++ b/.github/workflows/approve-pr.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@v4
         with:
           pull-request-number: ${{ github.event.inputs.pullRequestNumber }}
           review-message: "${{ github.triggering_actor }} triggered an approval of this PR via workflow."

--- a/.github/workflows/fallow-report.yml
+++ b/.github/workflows/fallow-report.yml
@@ -18,10 +18,10 @@ jobs:
     name: "Fallow / Health Report"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       build: ${{ steps.decide.outputs.build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@master
         id: filter
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout App Release Tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -113,7 +113,7 @@ jobs:
       - name: Generate ops token
         if: github.ref == 'refs/heads/master'
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
       - uses: wreality/helm-push@v1.1.1
         id: helm-push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,17 +9,17 @@ jobs:
     steps:
       - name: Generate Token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.token.outputs.token }}
       - name: Checkout Repository
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.token }}
       - name: Get GitHub App User ID

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,9 +80,10 @@ jobs:
           use_oidc: true
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage-web/junit.xml
+          report_type: test_results
           flags: client
           fail_ci_if_error: false
           use_oidc: true
@@ -192,9 +193,10 @@ jobs:
           use_oidc: true
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage-fpm/junit.xml
+          report_type: test_results
           flags: backend
           fail_ci_if_error: false
           use_oidc: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
       md: ${{ steps.filter.outputs.md }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dorny/paths-filter@master
         id: filter
         with:
@@ -61,7 +61,7 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.client == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -72,7 +72,7 @@ jobs:
           target: "web-test-ci"
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage-web/cobertura-coverage.xml
           flags: client
@@ -97,10 +97,10 @@ jobs:
       pull-requests: write
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn
@@ -135,12 +135,12 @@ jobs:
     outputs:
       version: ${{ steps.build-image.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -173,7 +173,7 @@ jobs:
           --health-retries 3
     if: ${{ needs.changes.outputs.api == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -184,7 +184,7 @@ jobs:
           target: "fpm-test-ci"
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage-fpm/cobertura.xml
           flags: backend
@@ -212,7 +212,7 @@ jobs:
     if: ${{ needs.changes.outputs.php == 'true' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -226,7 +226,7 @@ jobs:
     if: ${{ needs.changes.outputs.js == 'true' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -240,8 +240,8 @@ jobs:
     if: ${{ needs.changes.outputs.docs == 'true' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: |
@@ -255,8 +255,8 @@ jobs:
     if: ${{ needs.changes.outputs.md == 'true' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: yarn


### PR DESCRIPTION
## What

Bumps the GitHub Actions flagged "Pending Approval" on the Renovate Dependency
Dashboard (#1722) to their new majors, repo-wide under `.github/`. Refs only —
this repo pins by version tag (`@v6`), so floating majors pick up the latest
patched release in each line.

Each major's breaking notes were checked against our actual usage (inputs,
outputs, runner). All jobs run on `ubuntu-24.04` (GitHub-hosted), which satisfies
the Node 24 runtime that several of these majors now require.

## Per-action risk

| Action | Old → New | Breaking change | Affects us? | Risk |
|---|---|---|---|---|
| `actions/checkout` | v3/v4 → **v6** | v5: Node 24 runtime. v6: token stored in `$RUNNER_TEMP` (transparent on GH runners) | No — inputs (`fetch-depth`/`fetch-tags`/`token`) unchanged | 🟢 Low |
| `actions/setup-node` | v3/v4 → **v6** | v5: Node 24, `always-auth` removed, auto-cache changes. v6: auto-cache npm-only | No — we set no `always-auth`; all yarn steps pass explicit `cache:`; `node-version` 20/22 resolve fine | 🟢 Low |
| `codecov/codecov-action` | v4 → **v6** | v5: CLI-wrapper rewrite, `file`→`files`/`plugin`→`plugins`; v6: Node 24 | No — we already use v5 names (`files`/`flags`/`fail_ci_if_error`/`use_oidc`); OIDC preserved. `@v6` → ≥v6.0.1 (VULN-1652 patch) | 🟡 Low — see note |
| `docker/login-action` | v2 → **v4** | v3: Node 20, v4: Node 24 + ESM | No — `registry`/`username`/`password` unchanged | 🟢 Low |
| `actions/create-github-app-token` | v2 → **v3** | v3.0: Node 24 + proxy needs `NODE_USE_ENV_PROXY=1`; v3.1: `app-id` deprecated → `client-id`, permission-inputs change (#358) | Inputs/outputs (`app-id`/`private-key` → `token`/`app-slug`) work | 🟠 Med — see note |
| `googleapis/release-please-action` | v4 → **v5** | v5: Node 24 only | No — outputs (`release_created`/`version`) unchanged, no new config requirement, token-only usage intact | 🟡 Low — gates releases |
| `hmarr/auto-approve-action` | v3 → **v4** | v4: Node 16→20 | No — `pull-request-number`/`review-message` unchanged | 🟢 Low |
| `codecov/test-results-action` | v1 → **codecov-action@v6** | Deprecated in favor of `codecov-action`; still Node 20 | Migrated — see below | 🟡 Low |

## CI deprecation warnings (rolled in)

Pulled the actual annotations off recent runs. Our major bumps already cleared the
Node-20 deprecation warnings for `checkout`, `setup-node`, `codecov-action`, and
`docker/login-action`. Two residual classes remained:

- **`codecov/test-results-action@v1`** — double-flagged (Node 20 **and** hard
  "deprecated in favor of `codecov-action`"). **Fixed here**: both usages (client +
  backend) now run a second `codecov/codecov-action@v6` step with
  `report-type: test_results`, per the upstream migration notice. Inputs and OIDC
  unchanged. Also resolves the recurring CI notice _"codecov-action should run once
  for coverage and once for test results."_
- **`docker/bake-action`, `docker/metadata-action`, `docker/setup-buildx-action`,
  `oras-project/setup-oras`, `mesh-research/github-actions/pilcrow-toolkit`** — still
  emit Node-20 warnings, but they are **internals of the external
  `mesh-research/github-actions/build-image@v2` composite**, not referenced in this
  repo. **Cannot be fixed here** — needs a bump in the `MESH-Research/github-actions`
  repo. Tracked in MESH-Research/github-actions#3.

Out of scope (noted, not changed): `dorny/paths-filter@master` ×2 uses a floating
mutable ref (supply-chain surface) — pin to a tag in a separate change if desired.
`runs-on` is `ubuntu-24.04` everywhere — pinned and current, no deprecation.

## Deferred — NOT in this PR

- **`cypress-io/github-action` v3 → v7** (`do-test-e2e.yml`): **skipped.** Repo is
  mid-migration Cypress → Playwright (#2258, OPEN). The only caller of
  `do-test-e2e.yml` (the `e2e` job in `testing.yml`) is **commented out**, so the
  cypress action is currently dead in CI — bumping it has no validation path and
  would collide with #2258 replacing it. Left `do-test-e2e.yml` and its composite
  `.github/actions/start-stack` (checkout/setup-node/upload-artifact still on
  v3/v4) **entirely untouched** for the same reason.
- **`actions/upload-artifact` v4 → v7**: the only usage is inside `do-test-e2e.yml`
  (cypress path), so it's deferred with the rest of that file. No other workflow
  uploads artifacts. (Researched anyway: v4→v7 is safe — immutability landed at v4;
  matrix naming `screenshots-${{ matrix.containers }}` stays unique; `archive`
  input is opt-in. Will fold into the Playwright PR.)

## Needs human eyes (release / publish pipeline)

These gate `release-please.yml`, `publish-docker.yaml`, `publish-helm.yaml`:

1. **`create-github-app-token` `@v3` resolves to ≥v3.1**, which **deprecates the
   `app-id` input** (we use it in `release-please.yml` + `publish-docker.yaml`).
   Still functional — emits a deprecation warning; migrate `app-id` → `client-id`
   later. v3.1 also has an undetailed "update permission inputs" change (#358);
   we pass no permission inputs (rely on defaults), so likely no impact, but worth
   a confirming glance since it mints the release/ops tokens.
2. **codecov OIDC on protected branches**: recurring upstream reports of
   `"Token required because branch is protected"` with the v5/v6 CLI wrapper +
   `use_oidc: true`. Not an input break. If it bites on a protected-branch event,
   the fallback is to wire `CODECOV_TOKEN`.
3. No HTTP(S) proxy in our runners, so the `create-github-app-token` proxy change
   (`NODE_USE_ENV_PROXY=1`) does **not** apply.

## Validation

- `actionlint`/`yamllint` not available locally; all 7 changed workflows pass a
  `yaml.safe_load` parse.
- No `always-auth` inputs anywhere; all setup-node yarn steps pass explicit `cache:`.
- Full validation is CI — opening this PR triggers it. Note `do-test-e2e.yml`'s
  caller is commented out, so the cypress job won't run here.

## Recommendation

**SPLIT-friendly but mergeable as one.** The four low-risk lanes
(checkout, setup-node, docker-login, auto-approve) are pure no-ops for our usage.
If a reviewer wants extra caution, **hold `release-please.yml` +
`publish-docker.yaml`** (the `create-github-app-token` + `release-please` bumps)
for a separate, watched merge so a release can be observed live — those only fire
on `master` push / tags and can't be exercised by this PR's CI. **No automerge.**
