### PR TITLE
ci: patch-coverage PR comment on forks, gate Codecov to origin

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,12 +103,15 @@ jobs:
             --src-roots client \
             --markdown-report patch-coverage-client.md \
             --fail-under=0 || true
+          # Trim per-hunk source from the report: keep header, file list, summary.
+          awk '/^## / && seen { exit } /^## Summary/ { seen=1 } { print }' \
+            patch-coverage-client.md > patch-coverage-client.trimmed.md
       - name: Comment patch coverage (client)
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: patch-coverage-client
-          path: patch-coverage-client.md
+          path: patch-coverage-client.trimmed.md
 
   client-fallow-audit:
     name: "Client / Fallow Audit"
@@ -237,12 +240,15 @@ jobs:
             --src-roots backend \
             --markdown-report patch-coverage-backend.md \
             --fail-under=0 || true
+          # Trim per-hunk source from the report: keep header, file list, summary.
+          awk '/^## / && seen { exit } /^## Summary/ { seen=1 } { print }' \
+            patch-coverage-backend.md > patch-coverage-backend.trimmed.md
       - name: Comment patch coverage (backend)
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: patch-coverage-backend
-          path: patch-coverage-backend.md
+          path: patch-coverage-backend.trimmed.md
   # e2e:
   #   name: "E2E Test"
   #   needs: [build-images]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,6 +16,7 @@ permissions:
   packages: write
   id-token: write
   contents: read
+  pull-requests: write
 concurrency:
   group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
@@ -70,8 +71,9 @@ jobs:
         name: Run Unit Tests
         with:
           target: "web-test-ci"
+      # Codecov runs on origin only (provides overall + trend + patch coverage).
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ github.repository == 'MESH-Research/Pilcrow' && !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage-web/cobertura-coverage.xml
@@ -79,7 +81,7 @@ jobs:
           fail_ci_if_error: false
           use_oidc: true
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ github.repository == 'MESH-Research/Pilcrow' && !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage-web/junit.xml
@@ -87,6 +89,24 @@ jobs:
           flags: client
           fail_ci_if_error: false
           use_oidc: true
+      # On forks (no Codecov), surface coverage of the CHANGED lines as a PR
+      # comment using only GITHUB_TOKEN — no external service, no secret.
+      - name: Patch coverage of change (client)
+        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        run: |
+          git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+          pipx install diff_cover
+          diff-cover ./coverage-web/cobertura-coverage.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --src-roots client \
+            --markdown-report patch-coverage-client.md \
+            --fail-under=0 || true
+      - name: Comment patch coverage (client)
+        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: patch-coverage-client
+          path: patch-coverage-client.md
 
   client-fallow-audit:
     name: "Client / Fallow Audit"
@@ -183,8 +203,9 @@ jobs:
       - uses: mesh-research/github-actions/build-image@v2
         with:
           target: "fpm-test-ci"
+      # Codecov runs on origin only (provides overall + trend + patch coverage).
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ github.repository == 'MESH-Research/Pilcrow' && !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage-fpm/cobertura.xml
@@ -192,7 +213,7 @@ jobs:
           fail_ci_if_error: false
           use_oidc: true
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ github.repository == 'MESH-Research/Pilcrow' && !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage-fpm/junit.xml
@@ -200,6 +221,24 @@ jobs:
           flags: backend
           fail_ci_if_error: false
           use_oidc: true
+      # On forks (no Codecov), surface coverage of the CHANGED lines as a PR
+      # comment using only GITHUB_TOKEN — no external service, no secret.
+      - name: Patch coverage of change (backend)
+        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        run: |
+          git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+          pipx install diff_cover
+          diff-cover ./coverage-fpm/cobertura.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --src-roots backend \
+            --markdown-report patch-coverage-backend.md \
+            --fail-under=0 || true
+      - name: Comment patch coverage (backend)
+        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: patch-coverage-backend
+          path: patch-coverage-backend.md
   # e2e:
   #   name: "E2E Test"
   #   needs: [build-images]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,10 +89,12 @@ jobs:
           flags: client
           fail_ci_if_error: false
           use_oidc: true
-      # On forks (no Codecov), surface coverage of the CHANGED lines as a PR
-      # comment using only GITHUB_TOKEN — no external service, no secret.
+      # Surface coverage of the CHANGED lines as a sticky PR comment using only
+      # GITHUB_TOKEN — no external service, no secret. Runs on every PR
+      # (including forks, which lack Codecov); on origin it duplicates Codecov's
+      # patch coverage but keeps the comment path exercised.
       - name: Patch coverage of change (client)
-        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         run: |
           git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           pipx install diff_cover
@@ -102,7 +104,7 @@ jobs:
             --markdown-report patch-coverage-client.md \
             --fail-under=0 || true
       - name: Comment patch coverage (client)
-        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: patch-coverage-client
@@ -221,10 +223,12 @@ jobs:
           flags: backend
           fail_ci_if_error: false
           use_oidc: true
-      # On forks (no Codecov), surface coverage of the CHANGED lines as a PR
-      # comment using only GITHUB_TOKEN — no external service, no secret.
+      # Surface coverage of the CHANGED lines as a sticky PR comment using only
+      # GITHUB_TOKEN — no external service, no secret. Runs on every PR
+      # (including forks, which lack Codecov); on origin it duplicates Codecov's
+      # patch coverage but keeps the comment path exercised.
       - name: Patch coverage of change (backend)
-        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         run: |
           git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           pipx install diff_cover
@@ -234,7 +238,7 @@ jobs:
             --markdown-report patch-coverage-backend.md \
             --fail-under=0 || true
       - name: Comment patch coverage (backend)
-        if: ${{ github.repository != 'MESH-Research/Pilcrow' && github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: patch-coverage-backend


### PR DESCRIPTION
## What

- **Codecov steps now run on origin only** (\`github.repository == 'MESH-Research/Pilcrow'\`). On origin they're unchanged — overall + trend + patch coverage as before.
- **On forks, surface coverage of the CHANGED lines** as a sticky PR comment via [\`diff-cover\`](https://github.com/Bachmann1234/diff_cover), rendered with \`marocchino/sticky-pull-request-comment\`. Uses only \`GITHUB_TOKEN\` — no external service, no secret. One comment per stack (client / backend).

## Why

Forks don't have Codecov's OIDC trust, so coverage is invisible on fork PRs. We don't need overall coverage there (origin's Codecov still gives that) — we want the **scope of the change** surfaced. Both stacks already emit cobertura reports, so this just consumes existing artifacts.

## Notes / follow-ups

- The fork path is **dormant on origin** (condition is \`repository != MESH-Research/Pilcrow\`), so this PR's own CI does **not** exercise it. It fires only on PRs opened from a fork.
- Reports are **non-gating** (\`--fail-under=0\`) — report only, no status check. Easy to tighten later (e.g. \`--fail-under=80\` on changed lines).
- \`--src-roots client\`/\`backend\` is a best guess at the cobertura path roots; if the first real fork PR shows "No lines with coverage information," the src-roots/path prefix needs a one-line tweak.
- Added \`pull-requests: write\` to the top-level \`permissions\` block for the sticky comment.