### PR TITLE
ci: fix diff-cover patch-coverage comments (cobertura source rewrite)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -98,10 +98,14 @@ jobs:
         run: |
           git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           pipx install diff_cover
+          # Cobertura from the build container records an absolute in-container
+          # <source> path; rewrite it to the checkout's client dir so diff-cover
+          # resolves files to client/… and matches the git diff paths.
+          sed -i -E "s#<source>.*</source>#<source>${GITHUB_WORKSPACE}/client</source>#" \
+            ./coverage-web/cobertura-coverage.xml
           diff-cover ./coverage-web/cobertura-coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
-            --src-roots client \
-            --markdown-report patch-coverage-client.md \
+            --format markdown:patch-coverage-client.md \
             --fail-under=0 || true
           # Trim per-hunk source from the report: keep header, file list, summary.
           awk '/^## / && seen { exit } /^## Summary/ { seen=1 } { print }' \
@@ -235,10 +239,15 @@ jobs:
         run: |
           git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           pipx install diff_cover
+          # Cobertura from the build container records <source>/var/www/html/app
+          # with filenames relative to app/; rewrite <source> to the checkout's
+          # backend/app dir so diff-cover resolves files to backend/app/… and
+          # matches the git diff paths.
+          sed -i -E "s#<source>.*</source>#<source>${GITHUB_WORKSPACE}/backend/app</source>#" \
+            ./coverage-fpm/cobertura.xml
           diff-cover ./coverage-fpm/cobertura.xml \
             --compare-branch=origin/${{ github.base_ref }} \
-            --src-roots backend \
-            --markdown-report patch-coverage-backend.md \
+            --format markdown:patch-coverage-backend.md \
             --fail-under=0 || true
           # Trim per-hunk source from the report: keep header, file list, summary.
           awk '/^## / && seen { exit } /^## Summary/ { seen=1 } { print }' \


### PR DESCRIPTION
## Problem

The patch-coverage PR comments added in #2331 always reported **"No lines with coverage information in this diff."**

Root cause: the cobertura reports are generated **inside the build container**, so their `<source>` element is an absolute in-container path (`/app` for client, `/var/www/html/app` for backend). On the runner that path doesn't exist, so diff-cover can't map covered files onto the diff paths. `--src-roots` can't override an absolute `<source>`.

## Fix

Rewrite `<source>` to the checkout dir before running diff-cover:
- **client** → `${GITHUB_WORKSPACE}/client` (vitest roots filenames at the client dir, e.g. `src/…`)
- **backend** → `${GITHUB_WORKSPACE}/backend/app` (phpunit roots `<source>` at `app/`, filenames like `Auth/Abilities/…`)

Also swaps the deprecated `--markdown-report` for `--format markdown:`.

## Validation

Verified on fork PR wreality/Pilcrow#75 (a replica of #2308 that exercises the fork path). Both comments now render real patch coverage:
- client **91%** (253 changed lines, 21 missing) with per-file breakdown
- backend **91%** (204 changed lines, 17 missing) with per-file breakdown

Note: this PR only edits the workflow, so its own coverage jobs are skipped (paths-filter) — it can't self-demonstrate. Validation is the fork run above.