### PR TITLE
feat(api): expose comment abilities as granted enum arrays

### DIFF
--- a/backend/app/Auth/Abilities/CommentAbility.php
+++ b/backend/app/Auth/Abilities/CommentAbility.php
@@ -17,12 +17,18 @@ namespace App\Auth\Abilities;
  * Held (conditionally) by every comment-capable role via the Reviewer base
  * grant; the app-administrator role moderates unconditionally through the
  * resolver's short-circuit.
+ *
+ * Cases annotated {@see Exposed} are part of the public GraphQL contract: they
+ * become values of the `CommentAbility` GraphQL enum and appear in the viewer's
+ * granted-abilities array on a comment. Unannotated cases stay server-only.
  */
 enum CommentAbility: string implements ScopedAbility
 {
     /** Edit a comment's content (and, for a top-level inline comment, style criteria / range). */
+    #[Exposed('Viewer may edit this comment — content and, for a top-level inline comment, style criteria and range.')]
     case Update = 'comment.update';
 
     /** Soft-delete a comment. */
+    #[Exposed('Viewer may delete this comment.')]
     case Delete = 'comment.delete';
 }

--- a/backend/app/Models/InlineComment.php
+++ b/backend/app/Models/InlineComment.php
@@ -7,6 +7,7 @@ use App\Events\InlineCommentAdded;
 use App\Events\InlineCommentReplyAdded;
 use App\Http\Traits\CreatedUpdatedBy;
 use App\Models\Contracts\Comment;
+use App\Models\Traits\HasCommentAbilities;
 use App\Models\Traits\ReadStatus;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -21,6 +22,7 @@ class InlineComment extends BaseModel implements Comment
     use CreatedUpdatedBy;
     use SoftDeletes;
     use ReadStatus;
+    use HasCommentAbilities;
 
     protected $casts = [
         'style_criteria' => 'json',

--- a/backend/app/Models/OverallComment.php
+++ b/backend/app/Models/OverallComment.php
@@ -7,6 +7,7 @@ use App\Events\OverallCommentAdded;
 use App\Events\OverallCommentReplyAdded;
 use App\Http\Traits\CreatedUpdatedBy;
 use App\Models\Contracts\Comment;
+use App\Models\Traits\HasCommentAbilities;
 use App\Models\Traits\ReadStatus;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -21,6 +22,7 @@ class OverallComment extends BaseModel implements Comment
     use CreatedUpdatedBy;
     use SoftDeletes;
     use ReadStatus;
+    use HasCommentAbilities;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/app/Models/Traits/HasCommentAbilities.php
+++ b/backend/app/Models/Traits/HasCommentAbilities.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Models\Traits;
+
+use App\Auth\Abilities\AbilityExposure;
+use App\Auth\Abilities\CommentAbility;
+use App\Auth\ScopedAbilityResolver;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * The client-facing `abilities` resolver shared by both comment models
+ * ({@see \App\Models\InlineComment}, {@see \App\Models\OverallComment} —
+ * replies are same-table rows, so the four GraphQL comment types are covered).
+ * One trait because a comment's authorization is uniform across the two models
+ * ({@see \App\Models\Contracts\Comment}).
+ */
+trait HasCommentAbilities
+{
+    /**
+     * The authenticated viewer's GRANTED abilities on this comment, as the
+     * exposed names of {@see CommentAbility} cases.
+     *
+     * Resolved through {@see ScopedAbilityResolver} — the same engine
+     * {@see \App\Policies\CommentPolicy} uses — against this comment's owning
+     * submission, with the authorship/reviewable predicate evaluated against
+     * the comment itself. So these client-facing values can never drift from
+     * real authorization. Only {@see \App\Auth\Abilities\Exposed} cases are
+     * evaluated. Guests get an empty array.
+     *
+     * UI hints only: the server still enforces every mutation with @can.
+     *
+     * @return array<int, string>
+     */
+    public function abilities(): array
+    {
+        /** @var \App\Models\User|null $user */
+        $user = Auth::user();
+        if ($user === null) {
+            return [];
+        }
+        $resolver = app(ScopedAbilityResolver::class);
+
+        $granted = [];
+        foreach (AbilityExposure::exposed(CommentAbility::class) as $exposedName => $exposure) {
+            /** @var \App\Auth\Abilities\CommentAbility $ability */
+            $ability = $exposure['case'];
+            if ($resolver->allows($user, $ability, $this)) {
+                $granted[] = $exposedName;
+            }
+        }
+
+        return $granted;
+    }
+}

--- a/backend/graphql/submission.comments.graphql
+++ b/backend/graphql/submission.comments.graphql
@@ -29,6 +29,10 @@ type InlineComment implements Comment {
     read_at: DateTimeUtc @rename(attribute: "readAt")
     from: Int
     to: Int
+    abilities: [CommentAbility!]!
+        @method(name: "abilities")
+        @with(relation: "submission.submissionAssignments")
+        @with(relation: "submission.publication.publicationAssignments")
 }
 
 """
@@ -54,6 +58,10 @@ type InlineCommentReply implements Comment {
     parent_id: ID!
     reply_to_id: ID!
     read_at: DateTimeUtc @rename(attribute: "readAt")
+    abilities: [CommentAbility!]!
+        @method(name: "abilities")
+        @with(relation: "submission.submissionAssignments")
+        @with(relation: "submission.publication.publicationAssignments")
 }
 
 """
@@ -71,6 +79,10 @@ type OverallComment implements Comment {
         createdBy: [ID!] @scope(name: "byAuthorIds")
     ): [OverallCommentReply!] @hasMany @softDeletes
     read_at: DateTimeUtc @rename(attribute: "readAt")
+    abilities: [CommentAbility!]!
+        @method(name: "abilities")
+        @with(relation: "submission.submissionAssignments")
+        @with(relation: "submission.publication.publicationAssignments")
 }
 
 """
@@ -87,6 +99,10 @@ type OverallCommentReply implements Comment {
     parent_id: ID!
     reply_to_id: ID!
     read_at: DateTimeUtc @rename(attribute: "readAt")
+    abilities: [CommentAbility!]!
+        @method(name: "abilities")
+        @with(relation: "submission.submissionAssignments")
+        @with(relation: "submission.publication.publicationAssignments")
 }
 
 extend input UpdateSubmissionInput {
@@ -155,7 +171,14 @@ interface Comment {
     updated_at: DateTimeUtc!
     deleted_at: DateTimeUtc
     read_at: DateTimeUtc @rename(attribute: "readAt")
+    abilities: [CommentAbility!]!
 }
+
+"""
+An ability on a single comment. The viewer's `abilities` array carries the
+granted ones; grants depend on authorship and the owning submission's status.
+"""
+enum CommentAbility @abilityEnum(enum: "App\\Auth\\Abilities\\CommentAbility")
 
 extend type Mutation @guard {
     markInlineCommentsRead(

--- a/backend/tests/Api/AbilitiesTest.php
+++ b/backend/tests/Api/AbilitiesTest.php
@@ -9,6 +9,7 @@ use App\Auth\Abilities\GlobalAbility;
 use App\Auth\Abilities\PublicationAbility;
 use App\Auth\Abilities\SubmissionAbility;
 use App\Auth\Roles\ScopedRole;
+use App\Models\InlineComment;
 use App\Models\Publication;
 use App\Models\Submission;
 use App\Models\User;
@@ -45,6 +46,7 @@ class AbilitiesTest extends ApiTestCase
             'UserAbility' => ['UserAbility', GlobalAbility::class],
             'PublicationAbility' => ['PublicationAbility', PublicationAbility::class],
             'SubmissionAbility' => ['SubmissionAbility', SubmissionAbility::class],
+            'CommentAbility' => ['CommentAbility', CommentAbility::class],
         ];
     }
 
@@ -114,7 +116,7 @@ class AbilitiesTest extends ApiTestCase
             }
         }
 
-        foreach ([SubmissionAbility::class, PublicationAbility::class] as $enum) {
+        foreach ([SubmissionAbility::class, PublicationAbility::class, CommentAbility::class] as $enum) {
             foreach (AbilityExposure::exposed($enum) as $exposedName => $exposure) {
                 $ability = $exposure['case'];
                 $this->assertArrayHasKey(
@@ -137,17 +139,13 @@ class AbilitiesTest extends ApiTestCase
      */
     public function testEveryGrantedScopedAbilityIsExposed(): void
     {
-        // Deliberately server-only: the deprecated LegacyUpdate bridge, and all
-        // of CommentAbility — comment types expose no abilities field (yet), so
-        // the whole enum has no wire surface.
+        // Deliberately server-only: the deprecated LegacyUpdate bridge.
         $serverOnly = [SubmissionAbility::LegacyUpdate];
-        $serverOnlyEnums = [CommentAbility::class];
 
         foreach (ScopedRole::cases() as $role) {
             foreach ($role->grants() as $grant) {
                 $ability = $grant->ability;
-                $isServerOnly = in_array($ability, $serverOnly, true)
-                    || in_array($ability::class, $serverOnlyEnums, true);
+                $isServerOnly = in_array($ability, $serverOnly, true);
                 if ($isServerOnly) {
                     continue;
                 }
@@ -404,5 +402,109 @@ class AbilitiesTest extends ApiTestCase
         );
 
         $response->assertJsonPath('data.publication.abilities', []);
+    }
+
+    /**
+     * Comment update/delete is authorship-conditioned AND windowed: the author
+     * (holding a scoped role on the parent submission) sees both granted while
+     * the submission is under review, and loses both once it leaves the
+     * reviewable window — the comment becomes part of the settled record.
+     *
+     * @return void
+     */
+    public function testCommentAbilitiesForAuthorTrackReviewableWindow(): void
+    {
+        $reviewer = User::factory()->create();
+        $this->actingAs($reviewer);
+        $submission = Submission::factory()
+            ->for(Publication::factory()->create())
+            ->hasAttached($reviewer, [], 'reviewers')
+            ->create(['status' => Submission::UNDER_REVIEW]);
+        InlineComment::withoutEvents(fn() => InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'created_by' => $reviewer->id,
+        ]));
+
+        $query = 'query getSubmission($id: ID!) {
+            submission(id: $id) {
+                inline_comments { abilities }
+            }
+        }';
+
+        $response = $this->graphQL($query, ['id' => $submission->id]);
+        $this->assertEqualsCanonicalizing(
+            ['update', 'delete'],
+            $response->json('data.submission.inline_comments.0.abilities')
+        );
+
+        $submission->update(['status' => Submission::ACCEPTED_AS_FINAL]);
+
+        $this->graphQL($query, ['id' => $submission->id])
+            ->assertJsonPath('data.submission.inline_comments.0.abilities', []);
+    }
+
+    /**
+     * A role holder who did NOT author the comment gets an empty granted array —
+     * the authorship predicate fails — even though they can view the submission.
+     *
+     * @return void
+     */
+    public function testCommentAbilitiesDeniedToNonAuthor(): void
+    {
+        $reviewer = User::factory()->create();
+        $author = User::factory()->create();
+        $this->actingAs($reviewer);
+        $submission = Submission::factory()
+            ->for(Publication::factory()->create())
+            ->hasAttached($reviewer, [], 'reviewers')
+            ->create(['status' => Submission::UNDER_REVIEW]);
+        InlineComment::withoutEvents(fn() => InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'created_by' => $author->id,
+        ]));
+
+        $response = $this->graphQL(
+            'query getSubmission($id: ID!) {
+                submission(id: $id) {
+                    inline_comments { abilities }
+                }
+            }',
+            ['id' => $submission->id]
+        );
+
+        $response->assertJsonPath('data.submission.inline_comments.0.abilities', []);
+    }
+
+    /**
+     * The application administrator role moderates: it holds update/delete on
+     * any comment regardless of authorship, via the resolver's short-circuit.
+     *
+     * @return void
+     */
+    public function testCommentAbilitiesForApplicationAdministrator(): void
+    {
+        $this->beAppAdmin();
+        $author = User::factory()->create();
+        $submission = Submission::factory()
+            ->for(Publication::factory()->create())
+            ->create(['status' => Submission::UNDER_REVIEW]);
+        InlineComment::withoutEvents(fn() => InlineComment::factory()->create([
+            'submission_id' => $submission->id,
+            'created_by' => $author->id,
+        ]));
+
+        $response = $this->graphQL(
+            'query getSubmission($id: ID!) {
+                submission(id: $id) {
+                    inline_comments { abilities }
+                }
+            }',
+            ['id' => $submission->id]
+        );
+
+        $this->assertEqualsCanonicalizing(
+            ['update', 'delete'],
+            $response->json('data.submission.inline_comments.0.abilities')
+        );
     }
 }

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -29,6 +29,7 @@ input ChangeSubmissionStatusInput {
 }
 
 interface Comment {
+  abilities: [CommentAbility!]!
   content: String!
   created_at: DateTimeUtc!
   created_by: User!
@@ -37,6 +38,20 @@ interface Comment {
   read_at: DateTimeUtc
   updated_at: DateTimeUtc!
   updated_by: User!
+}
+
+"""
+An ability on a single comment. The viewer's `abilities` array carries the
+granted ones; grants depend on authorship and the owning submission's status.
+"""
+enum CommentAbility {
+  """Viewer may delete this comment."""
+  delete
+
+  """
+  Viewer may edit this comment — content and, for a top-level inline comment, style criteria and range.
+  """
+  update
 }
 
 """The type of comments to find participants for"""
@@ -178,6 +193,7 @@ type IdentityProvider {
 
 """An inline comment of a submission"""
 type InlineComment implements Comment {
+  abilities: [CommentAbility!]!
   content: String!
   created_at: DateTimeUtc!
   created_by: User!
@@ -204,6 +220,7 @@ input InlineCommentHasManyInput {
 
 """A reply to an inline comment of a submission"""
 type InlineCommentReply implements Comment {
+  abilities: [CommentAbility!]!
   content: String!
   created_at: DateTimeUtc!
   created_by: User!
@@ -490,6 +507,7 @@ enum OrderByRelationWithColumnAggregateFunction {
 
 """An overall comment of a submission"""
 type OverallComment implements Comment {
+  abilities: [CommentAbility!]!
   content: String!
   created_at: DateTimeUtc!
   created_by: User!
@@ -513,6 +531,7 @@ input OverallCommentHasManyInput {
 
 """A reply to an overall comment of a submission"""
 type OverallCommentReply implements Comment {
+  abilities: [CommentAbility!]!
   content: String!
   created_at: DateTimeUtc!
   created_by: User!


### PR DESCRIPTION
## What

Expose per-comment scoped abilities to the client: comment types (inline / overall, top-level and replies) gain

```graphql
abilities: [CommentAbility!]!   # e.g. ["update", "delete"]
```

resolved through the same `ScopedAbilityResolver` engine `CommentPolicy` uses, so the client hints cannot drift from real authorization. `CommentAbility::Update` / `::Delete` are now `#[Exposed]`, the `CommentAbility` GraphQL enum is generated by `@abilityEnum` (#2336 machinery), and both comment models share one `HasCommentAbilities` trait for the resolver method. The `abilities` fields carry `@with` eager-load hints (`submission.submissionAssignments`, `submission.publication.publicationAssignments`) so list reads don't N+1 the role pivots.

## Why

The client currently decides comment edit/delete affordances by comparing `created_by` to the current user — a re-implementation of the ownership rule that has already drifted from the server (it ignores the reviewable window and app-admin moderation). With granted abilities on the wire, the UI can gate on presence in the array, same as submission/publication abilities after #2336.

This removes the `(yet)` in `AbilitiesTest`'s server-only allowlist: `CommentAbility` joins the exposed vocabulary and both conformance checks (every exposed ability granted somewhere; every granted ability exposed).

## Notes

- Grants themselves are untouched — they land with #2334 (`OwnsCommentWhileReviewable` on the Reviewer base grant, app-admin short-circuit). This PR only puts the verdicts on the wire.
- Creation stays gated by `submission.review`; no `create` case on `CommentAbility`.
- The deprecated `updateSubmission` comment paths still use the frozen `created_by` check; the exposed abilities match the intent-shaped mutations' `@canFind` gates.
- Client-side gating that consumes these fields comes as a follow-up PR.

## Verification

Ran in a Lando stack (fresh rebuild, `migrate:fresh` on dev + testing DBs, Lighthouse cache cleared):

- `lando backend-test`: full suite passed (668 tests / 1393 assertions) — includes the new comment-ability API tests (author / non-author / app-admin / reviewable-window), the `CommentAbility` entry in the generated-enum conformance data set, and `SchemaSnapshotTest` against the regenerated snapshot.
- `lando backend-lint`: clean.
- Client: `graphql:codegen` regenerated the schema snapshot, `vue-tsc --noEmit` clean, `yarn lint` 0 errors, `yarn test:unit:ci` 506 passed (91 files).
- CI: all checks green on the staging branch run.

Not run: Playwright E2E.
